### PR TITLE
Feature/cloudplatform 426 securitygroup

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -38,7 +38,7 @@ stages:
               curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | CHANNEL=stable VERSION=${CROSSPLANE_VERSION} sh \
               && mv kubectl-crossplane /usr/local/bin
             displayName: Install Crossplane
-          
+
           - script: |
               cd package
               rm -f *.xpkg
@@ -54,7 +54,7 @@ stages:
             displayName: Docker login
 
           - script: |
-              export PACKAGEVERSION=`cut -d "/" -f3- <<< $(Build.SourceBranch)`
+              export PACKAGEVERSION=`sed s#/#-#g <<< $(Build.SourceBranch)`
               cd package
               kubectl crossplane push configuration dfdsdk/dfds-infra:$PACKAGEVERSION
             displayName: Push configuration

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
             displayName: Docker login
 
           - script: |
-              export PACKAGEVERSION=`sed s#/#-#g <<< $(Build.SourceBranch)`
+              export PACKAGEVERSION=`(sed s#/#-#g | sed s#refs-heads-##g) <<< $(Build.SourceBranch)`
               cd package
               kubectl crossplane push configuration dfdsdk/dfds-infra:$PACKAGEVERSION
             displayName: Push configuration

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
             displayName: Docker login
 
           - script: |
-              export PACKAGEVERSION=`(sed s#/#-#g | sed s#refs-heads-##g) <<< $(Build.SourceBranch)`
+              export PACKAGEVERSION=`(cut -d "/" -f3- | sed s#/#-#g) <<< $(Build.SourceBranch)`
               cd package
               kubectl crossplane push configuration dfdsdk/dfds-infra:$PACKAGEVERSION
             displayName: Push configuration

--- a/examples/aws/securitygroup/securitygroupclaim.yaml
+++ b/examples/aws/securitygroup/securitygroupclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: ec2.crossplane.dfds.cloud/v1alpha1
+apiVersion: network.crossplane.dfds.cloud/v1alpha1
 kind: AWSSecurityGroup
 metadata:
   name: securitygrouptestdfdswrapper

--- a/examples/aws/securitygroup/securitygroupclaim.yaml
+++ b/examples/aws/securitygroup/securitygroupclaim.yaml
@@ -1,0 +1,16 @@
+apiVersion: ec2.crossplane.dfds.cloud/v1alpha1
+kind: AWSSecurityGroup
+metadata:
+  name: securitygrouptestdfdswrapper
+  namespace: my-namespace
+spec:
+  parameters:
+    region: eu-west-1
+    groupName: jolly-roger
+    description: "A test securitygroup"
+    tags:
+      - key: Name
+        value: jolly-roger
+  compositionSelector:
+    matchLabels:
+      provider: aws

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawssecuritygroups.ec2.crossplane.dfds.cloud
+  name: xawssecuritygroups.network.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: ec2.crossplane.dfds.cloud/v1alpha1
+    apiVersion: network.crossplane.dfds.cloud/v1alpha1
     kind: XAWSSecurityGroup
 
   patchSets:

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xawssecuritygroups.ec2.crossplane.dfds.cloud
+  labels:
+    provider: aws
+spec:
+  compositeTypeRef:
+    apiVersion: ec2.crossplane.dfds.cloud/v1alpha1
+    kind: XAWSSecurityGroup
+
+  patchSets:
+    - name: configname
+      patches:
+        - fromFieldPath: spec.claimRef.namespace
+          toFieldPath: spec.providerConfigRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-aws"
+          policy:
+            fromFieldPath: Required
+
+  resources:
+    - name: rbac
+      base:
+        apiVersion: crossplane.dfds.cloud/v1alpha1
+        kind: XRBAC
+        spec:
+          resourceTypes:
+            - securitygroups
+          apiGroups:
+            - ec2.aws.crossplane.io
+          providerConfigRef:
+            name: kubernetes-provider
+      patches:
+        - fromFieldPath: metadata.name
+          toFieldPath: spec.resourceName
+        - fromFieldPath: spec.claimRef.namespace
+          toFieldPath: spec.resourceNamespace
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.createdResources
+          toFieldPath: status.createdResources.rbac
+          policy:
+            fromFieldPath: Optional
+
+    - name: securitygroup
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: SecurityGroup
+        spec:
+          forProvider:
+            region: eu-west-1
+      patches:
+        - type: PatchSet
+          patchSetName: configname
+        - fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+        - fromFieldPath: spec.parameters
+          toFieldPath: spec.forProvider
+        - type: ToCompositeFieldPath
+          fromFieldPath: "metadata.name"
+          toFieldPath: "status.createdResources.securitygroup"

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawssecuritygroups.ec2.crossplane.dfds.cloud
+  name: xawssecuritygroups.network.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awssecuritygroups.ec2.crossplane.dfds.cloud
-  group: ec2.crossplane.dfds.cloud
+    name: awssecuritygroups.network.crossplane.dfds.cloud
+  group: network.crossplane.dfds.cloud
   names:
     kind: XAWSSecurityGroup
     plural: xawssecuritygroups

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -1,0 +1,488 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xawssecuritygroups.ec2.crossplane.dfds.cloud
+spec:
+  defaultCompositionRef:
+    name: awssecuritygroups.ec2.crossplane.dfds.cloud
+  group: ec2.crossplane.dfds.cloud
+  names:
+    kind: XAWSSecurityGroup
+    plural: xawssecuritygroups
+  claimNames:
+    kind: AWSSecurityGroup
+    plural: awssecuritygroups
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                createdResources:
+                  description: list of resources created for this claim
+                  type: object
+                  properties:
+                    securitygroup:
+                      description: Name of the provisioned securitygroup
+                      type: string
+                    rbac:
+                      description: list of the provisioned RBAC resources
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    description:
+                      description: A description of the security group.
+                      type: string
+                    egress:
+                      description:
+                        "[EC2-VPC] One or more outbound rules associated
+                        with the security group."
+                      items:
+                        description:
+                          IPPermission Describes a set of permissions for
+                          a security group rule.
+                        properties:
+                          fromPort:
+                            description:
+                              The start of port range for the TCP and UDP
+                              protocols, or an ICMP/ICMPv6 type number. A value of -1
+                              indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
+                              types, you must specify all codes.
+                            format: int32
+                            type: integer
+                          ipProtocol:
+                            description:
+                              "The IP protocol name (tcp, udp, icmp, icmpv6)
+                              or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
+                              \n [VPC only] Use -1 to specify all protocols. When authorizing
+                              security group rules, specifying -1 or a protocol number
+                              other than tcp, udp, icmp, or icmpv6 allows traffic on
+                              all ports, regardless of any port range you specify. For
+                              tcp, udp, and icmp, you must specify a port range. For
+                              icmpv6, the port range is optional; if you omit the port
+                              range, traffic for all types and codes is allowed."
+                            type: string
+                          ipRanges:
+                            description: The IPv4 ranges.
+                            items:
+                              description: IPRange describes an IPv4 range.
+                              properties:
+                                cidrIp:
+                                  description:
+                                    The IPv4 CIDR range. You can either specify
+                                    a CIDR range or a source security group, not both.
+                                    To specify a single IPv4 address, use the /32 prefix
+                                    length.
+                                  type: string
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this IPv4 address range. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                  type: string
+                              required:
+                                - cidrIp
+                              type: object
+                            type: array
+                          ipv6Ranges:
+                            description: "The IPv6 ranges. \n [VPC only]"
+                            items:
+                              description: IPv6Range describes an IPv6 range.
+                              properties:
+                                cidrIPv6:
+                                  description:
+                                    The IPv6 CIDR range. You can either specify
+                                    a CIDR range or a source security group, not both.
+                                    To specify a single IPv6 address, use the /128 prefix
+                                    length.
+                                  type: string
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this IPv6 address range. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                  type: string
+                              required:
+                                - cidrIPv6
+                              type: object
+                            type: array
+                          prefixListIds:
+                            description:
+                              "PrefixListIDs for an AWS service. With outbound
+                              rules, this is the AWS service to access through a VPC
+                              endpoint from instances associated with the security group.
+                              \n [VPC only]"
+                            items:
+                              description: PrefixListID describes a prefix list ID.
+                              properties:
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this prefix list ID. \n Constraints:
+                                    Up to 255 characters in length. Allowed characters
+                                    are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                  type: string
+                                prefixListId:
+                                  description: The ID of the prefix.
+                                  type: string
+                              required:
+                                - prefixListId
+                              type: object
+                            type: array
+                          toPort:
+                            description:
+                              The end of port range for the TCP and UDP protocols,
+                              or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
+                              codes. If you specify all ICMP/ICMPv6 types, you must
+                              specify all codes.
+                            format: int32
+                            type: integer
+                          userIdGroupPairs:
+                            description:
+                              UserIDGroupPairs are the source security group
+                              and AWS account ID pairs. It contains one or more accounts
+                              and security groups to allow flows from security groups
+                              of other accounts.
+                            items:
+                              description:
+                                UserIDGroupPair describes a security group
+                                and AWS account ID pair.
+                              properties:
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this user ID group pair. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                  type: string
+                                groupId:
+                                  description: The ID of the security group.
+                                  type: string
+                                groupName:
+                                  description:
+                                    "The name of the security group. In a
+                                    request, use this parameter for a security group
+                                    in EC2-Classic or a default VPC only. For a security
+                                    group in a nondefault VPC, use the security group
+                                    ID. \n For a referenced security group in another
+                                    VPC, this value is not returned if the referenced
+                                    security group is deleted."
+                                  type: string
+                                userId:
+                                  description:
+                                    "The ID of an AWS account. \n For a referenced
+                                    security group in another VPC, the account ID of
+                                    the referenced security group is returned in the
+                                    response. If the referenced security group is deleted,
+                                    this value is not returned. \n [EC2-Classic] Required
+                                    when adding or removing rules that reference a security
+                                    group in another AWS account."
+                                  type: string
+                                vpcId:
+                                  description:
+                                    The ID of the VPC for the referenced
+                                    security group, if applicable.
+                                  type: string
+                                vpcIdRef:
+                                  description:
+                                    VPCIDRef reference a VPC to retrieve
+                                    its vpcId
+                                  properties:
+                                    name:
+                                      description: Name of the referenced object.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                vpcIdSelector:
+                                  description:
+                                    VPCIDSelector selects reference to a
+                                    VPC to retrieve its vpcId
+                                  properties:
+                                    matchControllerRef:
+                                      description:
+                                        MatchControllerRef ensures an object
+                                        with the same controller reference as the selecting
+                                        object is selected.
+                                      type: boolean
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description:
+                                        MatchLabels ensures an object with
+                                        matching labels is selected.
+                                      type: object
+                                  type: object
+                                vpcPeeringConnectionId:
+                                  description:
+                                    The ID of the VPC peering connection,
+                                    if applicable.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                          - ipProtocol
+                        type: object
+                      type: array
+                    groupName:
+                      description: The name of the security group.
+                      type: string
+                    ingress:
+                      description:
+                        One or more inbound rules associated with the security
+                        group.
+                      items:
+                        description:
+                          IPPermission Describes a set of permissions for
+                          a security group rule.
+                        properties:
+                          fromPort:
+                            description:
+                              The start of port range for the TCP and UDP
+                              protocols, or an ICMP/ICMPv6 type number. A value of -1
+                              indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
+                              types, you must specify all codes.
+                            format: int32
+                            type: integer
+                          ipProtocol:
+                            description:
+                              "The IP protocol name (tcp, udp, icmp, icmpv6)
+                              or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
+                              \n [VPC only] Use -1 to specify all protocols. When authorizing
+                              security group rules, specifying -1 or a protocol number
+                              other than tcp, udp, icmp, or icmpv6 allows traffic on
+                              all ports, regardless of any port range you specify. For
+                              tcp, udp, and icmp, you must specify a port range. For
+                              icmpv6, the port range is optional; if you omit the port
+                              range, traffic for all types and codes is allowed."
+                            type: string
+                          ipRanges:
+                            description: The IPv4 ranges.
+                            items:
+                              description: IPRange describes an IPv4 range.
+                              properties:
+                                cidrIp:
+                                  description:
+                                    The IPv4 CIDR range. You can either specify
+                                    a CIDR range or a source security group, not both.
+                                    To specify a single IPv4 address, use the /32 prefix
+                                    length.
+                                  type: string
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this IPv4 address range. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                  type: string
+                              required:
+                                - cidrIp
+                              type: object
+                            type: array
+                          ipv6Ranges:
+                            description: "The IPv6 ranges. \n [VPC only]"
+                            items:
+                              description: IPv6Range describes an IPv6 range.
+                              properties:
+                                cidrIPv6:
+                                  description:
+                                    The IPv6 CIDR range. You can either specify
+                                    a CIDR range or a source security group, not both.
+                                    To specify a single IPv6 address, use the /128 prefix
+                                    length.
+                                  type: string
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this IPv6 address range. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                  type: string
+                              required:
+                                - cidrIPv6
+                              type: object
+                            type: array
+                          prefixListIds:
+                            description:
+                              "PrefixListIDs for an AWS service. With outbound
+                              rules, this is the AWS service to access through a VPC
+                              endpoint from instances associated with the security group.
+                              \n [VPC only]"
+                            items:
+                              description: PrefixListID describes a prefix list ID.
+                              properties:
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this prefix list ID. \n Constraints:
+                                    Up to 255 characters in length. Allowed characters
+                                    are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                  type: string
+                                prefixListId:
+                                  description: The ID of the prefix.
+                                  type: string
+                              required:
+                                - prefixListId
+                              type: object
+                            type: array
+                          toPort:
+                            description:
+                              The end of port range for the TCP and UDP protocols,
+                              or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
+                              codes. If you specify all ICMP/ICMPv6 types, you must
+                              specify all codes.
+                            format: int32
+                            type: integer
+                          userIdGroupPairs:
+                            description:
+                              UserIDGroupPairs are the source security group
+                              and AWS account ID pairs. It contains one or more accounts
+                              and security groups to allow flows from security groups
+                              of other accounts.
+                            items:
+                              description:
+                                UserIDGroupPair describes a security group
+                                and AWS account ID pair.
+                              properties:
+                                description:
+                                  description:
+                                    "A description for the security group
+                                    rule that references this user ID group pair. \n
+                                    Constraints: Up to 255 characters in length. Allowed
+                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                  type: string
+                                groupId:
+                                  description: The ID of the security group.
+                                  type: string
+                                groupName:
+                                  description:
+                                    "The name of the security group. In a
+                                    request, use this parameter for a security group
+                                    in EC2-Classic or a default VPC only. For a security
+                                    group in a nondefault VPC, use the security group
+                                    ID. \n For a referenced security group in another
+                                    VPC, this value is not returned if the referenced
+                                    security group is deleted."
+                                  type: string
+                                userId:
+                                  description:
+                                    "The ID of an AWS account. \n For a referenced
+                                    security group in another VPC, the account ID of
+                                    the referenced security group is returned in the
+                                    response. If the referenced security group is deleted,
+                                    this value is not returned. \n [EC2-Classic] Required
+                                    when adding or removing rules that reference a security
+                                    group in another AWS account."
+                                  type: string
+                                vpcId:
+                                  description:
+                                    The ID of the VPC for the referenced
+                                    security group, if applicable.
+                                  type: string
+                                vpcIdRef:
+                                  description:
+                                    VPCIDRef reference a VPC to retrieve
+                                    its vpcId
+                                  properties:
+                                    name:
+                                      description: Name of the referenced object.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                vpcIdSelector:
+                                  description:
+                                    VPCIDSelector selects reference to a
+                                    VPC to retrieve its vpcId
+                                  properties:
+                                    matchControllerRef:
+                                      description:
+                                        MatchControllerRef ensures an object
+                                        with the same controller reference as the selecting
+                                        object is selected.
+                                      type: boolean
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description:
+                                        MatchLabels ensures an object with
+                                        matching labels is selected.
+                                      type: object
+                                  type: object
+                                vpcPeeringConnectionId:
+                                  description:
+                                    The ID of the VPC peering connection,
+                                    if applicable.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                          - ipProtocol
+                        type: object
+                      type: array
+                    region:
+                      description:
+                        Region is the region you'd like your SecurityGroup
+                        to be created in.
+                      type: string
+                    tags:
+                      description: Tags represents to current ec2 tags.
+                      items:
+                        description: Tag defines a tag
+                        properties:
+                          key:
+                            description: Key is the name of the tag.
+                            type: string
+                          value:
+                            description: Value is the value of the tag.
+                            type: string
+                        required:
+                          - key
+                          - value
+                        type: object
+                      type: array
+                    vpcId:
+                      description: VPCID is the ID of the VPC.
+                      type: string
+                    vpcIdRef:
+                      description: VPCIDRef references a VPC to and retrieves its vpcId
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    vpcIdSelector:
+                      description:
+                        VPCIDSelector selects a reference to a VPC to and
+                        retrieves its vpcId
+                      properties:
+                        matchControllerRef:
+                          description:
+                            MatchControllerRef ensures an object with the
+                            same controller reference as the selecting object is selected.
+                          type: boolean
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description:
+                            MatchLabels ensures an object with matching labels
+                            is selected.
+                          type: object
+                      type: object
+                  required:
+                    - description
+                    - groupName


### PR DESCRIPTION
- Add definition, composition and example claim for creating security group on AWS. 
- In the pipeline script, change the file line endings from CRLF to LF
- In the pipeline script, change the way a package version is determined by replacing slashes with dashes, because Docker Hub doesn't support slashes.
- Evidence that it works shown in screendump:
![Screenshot 2021-11-23 at 09 49 21](https://user-images.githubusercontent.com/20299875/142994374-ea4bb14f-082b-4849-93de-8392707890ca.png)


