### PR TITLE
Fix open source crossplane dependency

### DIFF
--- a/examples/sqldatabases/claim-dynamic-nonproduction.yaml
+++ b/examples/sqldatabases/claim-dynamic-nonproduction.yaml
@@ -9,6 +9,3 @@ spec:
   compositionSelector:
     matchLabels:
       provider: aws
-  
-  writeConnectionSecretToRef:
-    name: dynamic-claim-sql-nonprod-example-secret

--- a/examples/sqldatabases/claim-dynamic-production.yaml
+++ b/examples/sqldatabases/claim-dynamic-production.yaml
@@ -1,7 +1,7 @@
 apiVersion: crossplane.dfds.cloud/v1alpha1
 kind: SqlDatabaseInstance
 metadata:
-  namespace: default
+  namespace: my-namespace
   name: dynamic-claim-sql-prod-example
 spec:
   parameters:
@@ -11,6 +11,3 @@ spec:
   compositionSelector:
     matchLabels:
       provider: aws
-  
-  writeConnectionSecretToRef:
-    name: dynamic-claim-sql-prod-example-secret

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dfds-infra
 spec:
   crossplane:
-    version: ">=v1.2.1"
+    version: ">=v1.4.0-0"
   dependsOn:
     - provider: crossplane/provider-aws
       version: ">=v0.20.1"

--- a/package/sqldatabases/composition.yaml
+++ b/package/sqldatabases/composition.yaml
@@ -125,7 +125,7 @@ spec:
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy  
       
-  - name: rdinstance
+  - name: rdsinstance
     base:
       apiVersion: database.aws.crossplane.io/v1beta1
       kind: RDSInstance
@@ -135,18 +135,21 @@ spec:
           vpcSecurityGroupIDSelector:
             matchControllerRef: true
         writeConnectionSecretToRef:
-          namespace: crossplane-system
+            namespace: crossplane-system
+            name: rdsinstance
     patches:
     - type: PatchSet
       patchSetName: configname    
     - fromFieldPath: metadata.name
       toFieldPath: metadata.name    
-    - fromFieldPath: "metadata.uid"
+    - fromFieldPath: "spec.claimRef.name"
       toFieldPath: "spec.writeConnectionSecretToRef.name"
       transforms:
       - type: string
         string:
-          fmt: "%s-databaseserver"
+          fmt: "%s-connection"
+    - fromFieldPath: "spec.claimRef.namespace"
+      toFieldPath: "spec.writeConnectionSecretToRef.namespace"
     - fromFieldPath: "spec.parameters.databaseEngine"
       toFieldPath: "spec.forProvider.engine"
     - fromFieldPath: "spec.parameters.databaseEngineVersion"
@@ -237,4 +240,3 @@ spec:
     - type: MatchString
       fieldPath: "status.atProvider.dbInstanceStatus"
       matchString: "available"
-  writeConnectionSecretsToNamespace: crossplane-system


### PR DESCRIPTION
This PR should make our configuration package compatible with both Upbound Universal Crossplane and Open Source Crossplane by altering the Crossplane version dependency in the package and removing the hard-coded requirement for crossplane-system namespace to exist for the SqlDatabaseInstance composition connection secret and instead use the claim's namespace