### PR TITLE
Cleanup refactor xrs

### DIFF
--- a/examples/aws/bucket/bucketclaim.yaml
+++ b/examples/aws/bucket/bucketclaim.yaml
@@ -1,12 +1,9 @@
 apiVersion: storage.crossplane.dfds.cloud/v1alpha1
 kind: AWSBucket
 metadata:
-  name: s3testdfdswrapper
-  namespace: dynamic-forms-dxp-enxjg
+  name: awsbucketdfds
+  namespace: my-namespace
 spec:
   parameters:
     locationConstraint: eu-west-1
     acl: public-read
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/containerregistry/containerregistryclaim.yaml
+++ b/examples/aws/containerregistry/containerregistryclaim.yaml
@@ -1,13 +1,10 @@
 apiVersion: crossplane.dfds.cloud/v1alpha1
-kind: ECR
+kind: AWSECR
 metadata:
   namespace: my-namespace
-  name: dynamic-claim-ecr-example
+  name: awscontainerregistrydfds
 spec:
   parameters:
     enableSecurityScanOnPush: false
     mutability: "IMMUTABLE"
     region: "eu-west-1"
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/iam/iamrolepolicyattachmentclaim.yaml
+++ b/examples/aws/iam/iamrolepolicyattachmentclaim.yaml
@@ -1,7 +1,8 @@
 apiVersion: identity.crossplane.dfds.cloud/v1alpha1
-kind: IAMRolePolicyAttachment
+kind: AWSIAMRolePolicyAttachment
 metadata:
-  name: s3-readonly
+  name: s3-readonly-dfds
+  namespace: my-namespace  
 spec:
   parameters:
     policyArn: arn:aws:iam::000000000000:policy/s3-bucket-read-all

--- a/examples/aws/iamrole/iamroleclaim.yaml
+++ b/examples/aws/iamrole/iamroleclaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: identity.crossplane.dfds.cloud/v1alpha1
 kind: AWSIAMRole
 metadata:
-  name: identitytestdfdswrapper
+  name: identitydfds
   namespace: my-namespace
 spec:
   parameters:
@@ -26,6 +26,3 @@ spec:
             }
         ]
       }
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/queue/queueclaim.yaml
+++ b/examples/aws/queue/queueclaim.yaml
@@ -2,6 +2,7 @@ apiVersion: messaging.crossplane.dfds.cloud/v1alpha1
 kind: AWSQueue
 metadata:
   name: sqsdfds
+  namespace: my-namespace
 spec:
   parameters:
     region: eu-west-1

--- a/examples/aws/queue/queueclaim.yaml
+++ b/examples/aws/queue/queueclaim.yaml
@@ -1,10 +1,7 @@
 apiVersion: messaging.crossplane.dfds.cloud/v1alpha1
 kind: AWSQueue
 metadata:
-  name: sqstestdfdswrapper
+  name: sqsdfds
 spec:
   parameters:
     region: eu-west-1
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/replicationgroup/replicationgroupclaim.yaml
+++ b/examples/aws/replicationgroup/replicationgroupclaim.yaml
@@ -1,12 +1,12 @@
 apiVersion: cache.crossplane.dfds.cloud/v1alpha1
 kind: AWSReplicationGroup
 metadata:
-  name: replicationgrouptestdfdswrapper
+  name: replicationgroupdfds
   namespace: my-namespace
 spec:
   parameters:
     applyModificationsImmediately: true
-    cacheNodeType: 'cache.r6g.large'
-    region: 'eu-west-1'
-    engine: 'redis'
-    replicationGroupDescription: 'My description'
+    cacheNodeType: cache.r6g.large
+    region: eu-west-1
+    engine: redis
+    replicationGroupDescription: My description

--- a/examples/aws/replicationgroup/replicationgroupclaim.yaml
+++ b/examples/aws/replicationgroup/replicationgroupclaim.yaml
@@ -10,6 +10,3 @@ spec:
     region: 'eu-west-1'
     engine: 'redis'
     replicationGroupDescription: 'My description'
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/securitygroup/securitygroupclaim.yaml
+++ b/examples/aws/securitygroup/securitygroupclaim.yaml
@@ -11,6 +11,3 @@ spec:
     tags:
       - key: Name
         value: jolly-roger
-  compositionSelector:
-    matchLabels:
-      provider: aws

--- a/examples/aws/securitygroup/securitygroupclaim.yaml
+++ b/examples/aws/securitygroup/securitygroupclaim.yaml
@@ -1,7 +1,7 @@
 apiVersion: network.crossplane.dfds.cloud/v1alpha1
 kind: AWSSecurityGroup
 metadata:
-  name: securitygrouptestdfdswrapper
+  name: securitygrouptestdfds
   namespace: my-namespace
 spec:
   parameters:

--- a/package/aws/bucket/composition.yaml
+++ b/package/aws/bucket/composition.yaml
@@ -1,9 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsbuckets.storage.crossplane.dfds.cloud
-  labels:
-    provider: aws
+  name: xawsbuckets.storage.crossplane.dfds.cloud  
 spec:
   compositeTypeRef:
     apiVersion: storage.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/bucket/composition.yaml
+++ b/package/aws/bucket/composition.yaml
@@ -57,5 +57,9 @@ spec:
     - fromFieldPath: spec.parameters
       toFieldPath: spec.forProvider
     - type: ToCompositeFieldPath
-      fromFieldPath: "metadata.name"
-      toFieldPath: "status.createdResources.bucket"      
+      fromFieldPath: metadata.name
+      toFieldPath: status.createdResources.bucket
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]" # enables using external name in claims      
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy

--- a/package/aws/bucket/definition.yaml
+++ b/package/aws/bucket/definition.yaml
@@ -40,6 +40,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                                        
                   accelerateConfiguration:
                     description: AccelerateConfiguration configures the transfer acceleration
                       state for an Amazon S3 bucket. For more information, see Amazon

--- a/package/aws/bucket/definition.yaml
+++ b/package/aws/bucket/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xawsbuckets.storage.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awsbuckets.storage.crossplane.dfds.cloud
+    name: xawsbuckets.storage.crossplane.dfds.cloud 
   group: storage.crossplane.dfds.cloud
   names:
     kind: XAWSBucket

--- a/package/aws/containerregistry/composition.yaml
+++ b/package/aws/containerregistry/composition.yaml
@@ -53,7 +53,7 @@ spec:
               value: crossplane
     patches:
     - type: PatchSet
-      patchSetName: configname
+      patchSetName: configname    
     - fromFieldPath: spec.parameters.enableSecurityScanOnPush
       toFieldPath: spec.forProvider.imageScanningConfiguration.scanOnPush
     - fromFieldPath: spec.parameters.mutability
@@ -62,6 +62,11 @@ spec:
       toFieldPath: spec.forProvider.region
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.name
+      toFieldPath: status.createdResources.repository
+      policy:
+        fromFieldPath: Optional
 
   - name: ecr-policy
     base:
@@ -87,3 +92,8 @@ spec:
       toFieldPath: spec.forProvider.region
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.name
+      toFieldPath: status.createdResources.repositorypolicy
+      policy:
+        fromFieldPath: Optional

--- a/package/aws/containerregistry/composition.yaml
+++ b/package/aws/containerregistry/composition.yaml
@@ -65,6 +65,10 @@ spec:
       toFieldPath: status.createdResources.repository
       policy:
         fromFieldPath: Optional
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]" # enables using external name in claims      
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy
 
   - name: ecr-policy
     base:
@@ -95,3 +99,7 @@ spec:
       toFieldPath: status.createdResources.repositorypolicy
       policy:
         fromFieldPath: Optional
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy

--- a/package/aws/containerregistry/composition.yaml
+++ b/package/aws/containerregistry/composition.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawsecrs.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: crossplane.dfds.cloud/v1alpha1

--- a/package/aws/containerregistry/composition.yaml
+++ b/package/aws/containerregistry/composition.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: compositeecr.crossplane.dfds.cloud
+  name: xawsecrs.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
     apiVersion: crossplane.dfds.cloud/v1alpha1
-    kind: CompositeECR
+    kind: XAWSECR
   patchSets:
   - name: configname
     patches:

--- a/package/aws/containerregistry/definition.yaml
+++ b/package/aws/containerregistry/definition.yaml
@@ -1,17 +1,17 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: compositeecrs.crossplane.dfds.cloud
+  name: xawsecrs.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: compositeecrs.crossplane.dfds.cloud
+    name: xawsecrs.crossplane.dfds.cloud
   group: crossplane.dfds.cloud
   names:
-    kind: CompositeECR
-    plural: compositeecrs
+    kind: XAWSECR
+    plural: xawsecrs
   claimNames:
-    kind: ECR
-    plural: ecrs
+    kind: AWSECR
+    plural: awsecrs
   versions:
   - name: v1alpha1
     served: true
@@ -20,6 +20,23 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          status:
+            type: object
+            properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  repository:
+                    description: Name of the provisioned repository
+                    type: string
+                  repositorypolicy:
+                    description: Name of the provisioned repositorypolicy
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true          
           spec:
             type: object
             properties:
@@ -50,36 +67,3 @@ spec:
                 - enableSecurityScanOnPush
             required:
             - parameters
-          status:
-            type: object
-            properties:
-              createdResources:
-                description: list of resources created for this claim
-                type: object
-                properties:
-                  repository:
-                    description: Name of the provisioned repository
-                    type: string
-                  repositorypolicy:
-                    description: Name of the provisioned repositorypolicy
-                    type: string
-                  clusterrole:
-                    description: Name of the provisioned clusterrole
-                    type: string
-                  clusterrolebinding:
-                    description: Name of the provisioned clusterrolebinding
-                    type: string
-    #           dbInstanceConditions:
-    #             description: >
-    #               Freeform field containing information about the RDS instance condition, e.g. reconcile errors due to bad parameters
-    #             type: array
-    #             items:
-    #               type: object
-    #               x-kubernetes-preserve-unknown-fields: true
-    # additionalPrinterColumns:
-    # - name: Synced
-    #   type: string
-    #   jsonPath: ".status.dbInstanceConditions[0].status"
-    # - name: Last Sync Date
-    #   type: string
-    #   jsonPath: ".status.dbInstanceConditions[0].lastTransitionTime"

--- a/package/aws/containerregistry/definition.yaml
+++ b/package/aws/containerregistry/definition.yaml
@@ -43,6 +43,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                
                   enableSecurityScanOnPush:
                     description: Enable image security scan on push.
                     type: boolean

--- a/package/aws/iam/composition.yaml
+++ b/package/aws/iam/composition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: iamrolepolicyattachments.identity.crossplane.dfds.cloud
+  name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:

--- a/package/aws/iam/composition.yaml
+++ b/package/aws/iam/composition.yaml
@@ -48,3 +48,7 @@ spec:
       toFieldPath: metadata.name          
     - fromFieldPath: spec.parameters
       toFieldPath: spec.forProvider
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy      

--- a/package/aws/iam/composition.yaml
+++ b/package/aws/iam/composition.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawsiamrolepolicyattachments.identity.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: identity.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/iam/composition.yaml
+++ b/package/aws/iam/composition.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
+  name: xawsiamrolepolicyattachments.identity.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
     apiVersion: identity.crossplane.dfds.cloud/v1alpha1
-    kind: XIAMRolePolicyAttachment
+    kind: XAWSIAMRolePolicyAttachment
 
   patchSets:
   - name: configname
@@ -37,7 +37,8 @@ spec:
     - fromFieldPath: metadata.name
       toFieldPath: spec.resourceName
     - fromFieldPath: spec.claimRef.namespace
-      toFieldPath: spec.resourceNamespace    
+      toFieldPath: spec.resourceNamespace
+          
   - name: iamRolePolicyAttachment
     base:
       apiVersion: identity.aws.crossplane.io/v1beta1

--- a/package/aws/iam/definition.yaml
+++ b/package/aws/iam/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: iamrolepolicyattachments.identity.crossplane.dfds.cloud
+    name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
   group: identity.crossplane.dfds.cloud
   names:
     kind: XIAMRolePolicyAttachment

--- a/package/aws/iam/definition.yaml
+++ b/package/aws/iam/definition.yaml
@@ -26,6 +26,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                
                   policyArn:
                     type: string
                   policyArnRef:

--- a/package/aws/iam/definition.yaml
+++ b/package/aws/iam/definition.yaml
@@ -1,17 +1,17 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
+  name: xawsiamrolepolicyattachments.identity.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xiamrolepolicyattachments.identity.crossplane.dfds.cloud
+    name: xawsiamrolepolicyattachments.identity.crossplane.dfds.cloud
   group: identity.crossplane.dfds.cloud
   names:
-    kind: XIAMRolePolicyAttachment
-    plural: xiamrolepolicyattachments
+    kind: XAWSIAMRolePolicyAttachment
+    plural: xawsiamrolepolicyattachments
   claimNames:
-    kind: IAMRolePolicyAttachment
-    plural: iamrolepolicyattachments
+    kind: AWSIAMRolePolicyAttachment
+    plural: awsiamrolepolicyattachments
   versions:
   - name: v1alpha1
     served: true

--- a/package/aws/iamrole/composition.yaml
+++ b/package/aws/iamrole/composition.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawsiamroles.identity.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: identity.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/iamrole/composition.yaml
+++ b/package/aws/iamrole/composition.yaml
@@ -33,6 +33,11 @@ spec:
     - type: ToCompositeFieldPath
       fromFieldPath: "metadata.name"
       toFieldPath: "status.createdResources.iamrole"
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy 
+            
   - name: rbac
     base:
       apiVersion: crossplane.dfds.cloud/v1alpha1

--- a/package/aws/iamrole/definition.yaml
+++ b/package/aws/iamrole/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xawsiamroles.identity.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awsiamroles.identity.crossplane.dfds.cloud
+    name: xawsiamroles.identity.crossplane.dfds.cloud
   group: identity.crossplane.dfds.cloud
   names:
     kind: XAWSIAMRole
@@ -20,6 +20,20 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          status:
+            type: object
+            properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  iamrole:
+                    description: Name of the provisioned IAM role
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true         
           spec:
             type: object
             properties:

--- a/package/aws/iamrole/definition.yaml
+++ b/package/aws/iamrole/definition.yaml
@@ -40,6 +40,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"               
                   assumeRolePolicyDocument:
                     description: AssumeRolePolicyDocument is the the trust relationship
                       policy document that grants an entity permission to assume the

--- a/package/aws/queue/composition.yaml
+++ b/package/aws/queue/composition.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawsqueues.messaging.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: messaging.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/queue/composition.yaml
+++ b/package/aws/queue/composition.yaml
@@ -51,3 +51,13 @@ spec:
       toFieldPath: metadata.name
     - fromFieldPath: spec.parameters
       toFieldPath: spec.forProvider
+    - type: ToCompositeFieldPath
+      fromFieldPath: metadata.name
+      toFieldPath: status.createdResources.sqs
+      policy:
+        fromFieldPath: Optional      
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional

--- a/package/aws/queue/composition.yaml
+++ b/package/aws/queue/composition.yaml
@@ -61,3 +61,7 @@ spec:
       toFieldPath: status.instanceConditions
       policy:
         fromFieldPath: Optional
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy         

--- a/package/aws/queue/definition.yaml
+++ b/package/aws/queue/definition.yaml
@@ -20,6 +20,27 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          status:
+            type: object
+            properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  sqs:
+                    description: Name of the provisioned SQS queue
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+              instanceConditions:
+                description: >
+                  Freeform field containing information about the instance condition, e.g. reconcile errors due to bad parameters
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true                    
           spec:
             type: object
             properties:

--- a/package/aws/queue/definition.yaml
+++ b/package/aws/queue/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xawsqueues.messaging.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awsqueues.messaging.crossplane.dfds.cloud
+    name: xawsqueues.messaging.crossplane.dfds.cloud
   group: messaging.crossplane.dfds.cloud
   names:
     kind: XAWSQueue

--- a/package/aws/queue/definition.yaml
+++ b/package/aws/queue/definition.yaml
@@ -47,6 +47,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                
                   contentBasedDeduplication:
                     description: 'ContentBasedDeduplication - Enables content-based
                       deduplication. Valid values: true, false. For more information,

--- a/package/aws/replicationgroup/compostion.yaml
+++ b/package/aws/replicationgroup/compostion.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawsreplicationgroups.cache.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: cache.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/replicationgroup/compostion.yaml
+++ b/package/aws/replicationgroup/compostion.yaml
@@ -58,4 +58,8 @@ spec:
       fromFieldPath: status.conditions
       toFieldPath: status.instanceConditions
       policy:
-        fromFieldPath: Optional      
+        fromFieldPath: Optional
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy         

--- a/package/aws/replicationgroup/compostion.yaml
+++ b/package/aws/replicationgroup/compostion.yaml
@@ -53,4 +53,9 @@ spec:
       toFieldPath: spec.forProvider
     - type: ToCompositeFieldPath
       fromFieldPath: "metadata.name"
-      toFieldPath: "status.createdResources.replicationgroup"      
+      toFieldPath: "status.createdResources.replicationgroup"
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional      

--- a/package/aws/replicationgroup/definition.yaml
+++ b/package/aws/replicationgroup/definition.yaml
@@ -47,6 +47,10 @@ spec:
               parameters:
                 type: object
                 properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                
                   applyModificationsImmediately:
                     description: "If true, this parameter causes the modifications
                       in this request and any pending modifications to be applied,

--- a/package/aws/replicationgroup/definition.yaml
+++ b/package/aws/replicationgroup/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xawsreplicationgroups.cache.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awsreplicationgroups.cache.crossplane.dfds.cloud
+    name: xawsreplicationgroups.cache.crossplane.dfds.cloud
   group: cache.crossplane.dfds.cloud
   names:
     kind: XAWSReplicationGroup
@@ -27,13 +27,20 @@ spec:
                 description: list of resources created for this claim
                 type: object
                 properties:
-                  bucket:
+                  replicationgroup:
                     description: Name of the provisioned replicationgroup
                     type: string
                   rbac:
                     description: list of the provisioned RBAC resources
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+              instanceConditions:
+                description: >
+                  Freeform field containing information about the instance condition, e.g. reconcile errors due to bad parameters
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true                      
           spec:
             type: object
             properties:

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: xawssecuritygroups.network.crossplane.dfds.cloud
-  labels:
-    provider: aws
 spec:
   compositeTypeRef:
     apiVersion: network.crossplane.dfds.cloud/v1alpha1

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -20,42 +20,46 @@ spec:
             fromFieldPath: Required
 
   resources:
-    - name: rbac
-      base:
-        apiVersion: crossplane.dfds.cloud/v1alpha1
-        kind: XRBAC
-        spec:
-          resourceTypes:
-            - securitygroups
-          apiGroups:
-            - ec2.aws.crossplane.io
-          providerConfigRef:
-            name: kubernetes-provider
-      patches:
-        - fromFieldPath: metadata.name
-          toFieldPath: spec.resourceName
-        - fromFieldPath: spec.claimRef.namespace
-          toFieldPath: spec.resourceNamespace
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.createdResources
-          toFieldPath: status.createdResources.rbac
-          policy:
-            fromFieldPath: Optional
+  - name: rbac
+    base:
+      apiVersion: crossplane.dfds.cloud/v1alpha1
+      kind: XRBAC
+      spec:
+        resourceTypes:
+          - securitygroups
+        apiGroups:
+          - ec2.aws.crossplane.io
+        providerConfigRef:
+          name: kubernetes-provider
+    patches:
+      - fromFieldPath: metadata.name
+        toFieldPath: spec.resourceName
+      - fromFieldPath: spec.claimRef.namespace
+        toFieldPath: spec.resourceNamespace
+      - type: ToCompositeFieldPath
+        fromFieldPath: status.createdResources
+        toFieldPath: status.createdResources.rbac
+        policy:
+          fromFieldPath: Optional
 
-    - name: securitygroup
-      base:
-        apiVersion: ec2.aws.crossplane.io/v1beta1
-        kind: SecurityGroup
-        spec:
-          forProvider:
-            region: eu-west-1
-      patches:
-        - type: PatchSet
-          patchSetName: configname
-        - fromFieldPath: metadata.name
-          toFieldPath: metadata.name
-        - fromFieldPath: spec.parameters
-          toFieldPath: spec.forProvider
-        - type: ToCompositeFieldPath
-          fromFieldPath: "metadata.name"
-          toFieldPath: "status.createdResources.securitygroup"
+  - name: securitygroup
+    base:
+      apiVersion: ec2.aws.crossplane.io/v1beta1
+      kind: SecurityGroup
+      spec:
+        forProvider:
+          region: eu-west-1
+    patches:
+    - type: PatchSet
+      patchSetName: configname
+    - fromFieldPath: metadata.name
+      toFieldPath: metadata.name
+    - fromFieldPath: spec.parameters
+      toFieldPath: spec.forProvider
+    - type: ToCompositeFieldPath
+      fromFieldPath: "metadata.name"
+      toFieldPath: "status.createdResources.securitygroup"
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy           

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -13,476 +13,480 @@ spec:
     kind: AWSSecurityGroup
     plural: awssecuritygroups
   versions:
-    - name: v1alpha1
-      served: true
-      referenceable: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          properties:
-            status:
-              type: object
-              properties:
-                createdResources:
-                  description: list of resources created for this claim
-                  type: object
-                  properties:
-                    securitygroup:
-                      description: Name of the provisioned securitygroup
-                      type: string
-                    rbac:
-                      description: list of the provisioned RBAC resources
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-            spec:
-              type: object
-              properties:
-                parameters:
-                  type: object
-                  properties:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            type: object
+            properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  securitygroup:
+                    description: Name of the provisioned securitygroup
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+          spec:
+            type: object
+            properties:
+              parameters:
+                type: object
+                properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"                   
+                  description:
+                    description: A description of the security group.
+                    type: string
+                  egress:
                     description:
-                      description: A description of the security group.
-                      type: string
-                    egress:
+                      "[EC2-VPC] One or more outbound rules associated
+                      with the security group."
+                    items:
                       description:
-                        "[EC2-VPC] One or more outbound rules associated
-                        with the security group."
-                      items:
-                        description:
-                          IPPermission Describes a set of permissions for
-                          a security group rule.
-                        properties:
-                          fromPort:
-                            description:
-                              The start of port range for the TCP and UDP
-                              protocols, or an ICMP/ICMPv6 type number. A value of -1
-                              indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
-                              types, you must specify all codes.
-                            format: int32
-                            type: integer
-                          ipProtocol:
-                            description:
-                              "The IP protocol name (tcp, udp, icmp, icmpv6)
-                              or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
-                              \n [VPC only] Use -1 to specify all protocols. When authorizing
-                              security group rules, specifying -1 or a protocol number
-                              other than tcp, udp, icmp, or icmpv6 allows traffic on
-                              all ports, regardless of any port range you specify. For
-                              tcp, udp, and icmp, you must specify a port range. For
-                              icmpv6, the port range is optional; if you omit the port
-                              range, traffic for all types and codes is allowed."
-                            type: string
-                          ipRanges:
-                            description: The IPv4 ranges.
-                            items:
-                              description: IPRange describes an IPv4 range.
-                              properties:
-                                cidrIp:
-                                  description:
-                                    The IPv4 CIDR range. You can either specify
-                                    a CIDR range or a source security group, not both.
-                                    To specify a single IPv4 address, use the /32 prefix
-                                    length.
-                                  type: string
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this IPv4 address range. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
-                                  type: string
-                              required:
-                                - cidrIp
-                              type: object
-                            type: array
-                          ipv6Ranges:
-                            description: "The IPv6 ranges. \n [VPC only]"
-                            items:
-                              description: IPv6Range describes an IPv6 range.
-                              properties:
-                                cidrIPv6:
-                                  description:
-                                    The IPv6 CIDR range. You can either specify
-                                    a CIDR range or a source security group, not both.
-                                    To specify a single IPv6 address, use the /128 prefix
-                                    length.
-                                  type: string
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this IPv6 address range. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
-                                  type: string
-                              required:
-                                - cidrIPv6
-                              type: object
-                            type: array
-                          prefixListIds:
-                            description:
-                              "PrefixListIDs for an AWS service. With outbound
-                              rules, this is the AWS service to access through a VPC
-                              endpoint from instances associated with the security group.
-                              \n [VPC only]"
-                            items:
-                              description: PrefixListID describes a prefix list ID.
-                              properties:
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this prefix list ID. \n Constraints:
-                                    Up to 255 characters in length. Allowed characters
-                                    are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
-                                  type: string
-                                prefixListId:
-                                  description: The ID of the prefix.
-                                  type: string
-                              required:
-                                - prefixListId
-                              type: object
-                            type: array
-                          toPort:
-                            description:
-                              The end of port range for the TCP and UDP protocols,
-                              or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
-                              codes. If you specify all ICMP/ICMPv6 types, you must
-                              specify all codes.
-                            format: int32
-                            type: integer
-                          userIdGroupPairs:
-                            description:
-                              UserIDGroupPairs are the source security group
-                              and AWS account ID pairs. It contains one or more accounts
-                              and security groups to allow flows from security groups
-                              of other accounts.
-                            items:
-                              description:
-                                UserIDGroupPair describes a security group
-                                and AWS account ID pair.
-                              properties:
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this user ID group pair. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
-                                  type: string
-                                groupId:
-                                  description: The ID of the security group.
-                                  type: string
-                                groupName:
-                                  description:
-                                    "The name of the security group. In a
-                                    request, use this parameter for a security group
-                                    in EC2-Classic or a default VPC only. For a security
-                                    group in a nondefault VPC, use the security group
-                                    ID. \n For a referenced security group in another
-                                    VPC, this value is not returned if the referenced
-                                    security group is deleted."
-                                  type: string
-                                userId:
-                                  description:
-                                    "The ID of an AWS account. \n For a referenced
-                                    security group in another VPC, the account ID of
-                                    the referenced security group is returned in the
-                                    response. If the referenced security group is deleted,
-                                    this value is not returned. \n [EC2-Classic] Required
-                                    when adding or removing rules that reference a security
-                                    group in another AWS account."
-                                  type: string
-                                vpcId:
-                                  description:
-                                    The ID of the VPC for the referenced
-                                    security group, if applicable.
-                                  type: string
-                                vpcIdRef:
-                                  description:
-                                    VPCIDRef reference a VPC to retrieve
-                                    its vpcId
-                                  properties:
-                                    name:
-                                      description: Name of the referenced object.
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                vpcIdSelector:
-                                  description:
-                                    VPCIDSelector selects reference to a
-                                    VPC to retrieve its vpcId
-                                  properties:
-                                    matchControllerRef:
-                                      description:
-                                        MatchControllerRef ensures an object
-                                        with the same controller reference as the selecting
-                                        object is selected.
-                                      type: boolean
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description:
-                                        MatchLabels ensures an object with
-                                        matching labels is selected.
-                                      type: object
-                                  type: object
-                                vpcPeeringConnectionId:
-                                  description:
-                                    The ID of the VPC peering connection,
-                                    if applicable.
-                                  type: string
-                              type: object
-                            type: array
-                        required:
-                          - ipProtocol
-                        type: object
-                      type: array
-                    groupName:
-                      description: The name of the security group.
-                      type: string
-                    ingress:
-                      description:
-                        One or more inbound rules associated with the security
-                        group.
-                      items:
-                        description:
-                          IPPermission Describes a set of permissions for
-                          a security group rule.
-                        properties:
-                          fromPort:
-                            description:
-                              The start of port range for the TCP and UDP
-                              protocols, or an ICMP/ICMPv6 type number. A value of -1
-                              indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
-                              types, you must specify all codes.
-                            format: int32
-                            type: integer
-                          ipProtocol:
-                            description:
-                              "The IP protocol name (tcp, udp, icmp, icmpv6)
-                              or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
-                              \n [VPC only] Use -1 to specify all protocols. When authorizing
-                              security group rules, specifying -1 or a protocol number
-                              other than tcp, udp, icmp, or icmpv6 allows traffic on
-                              all ports, regardless of any port range you specify. For
-                              tcp, udp, and icmp, you must specify a port range. For
-                              icmpv6, the port range is optional; if you omit the port
-                              range, traffic for all types and codes is allowed."
-                            type: string
-                          ipRanges:
-                            description: The IPv4 ranges.
-                            items:
-                              description: IPRange describes an IPv4 range.
-                              properties:
-                                cidrIp:
-                                  description:
-                                    The IPv4 CIDR range. You can either specify
-                                    a CIDR range or a source security group, not both.
-                                    To specify a single IPv4 address, use the /32 prefix
-                                    length.
-                                  type: string
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this IPv4 address range. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
-                                  type: string
-                              required:
-                                - cidrIp
-                              type: object
-                            type: array
-                          ipv6Ranges:
-                            description: "The IPv6 ranges. \n [VPC only]"
-                            items:
-                              description: IPv6Range describes an IPv6 range.
-                              properties:
-                                cidrIPv6:
-                                  description:
-                                    The IPv6 CIDR range. You can either specify
-                                    a CIDR range or a source security group, not both.
-                                    To specify a single IPv6 address, use the /128 prefix
-                                    length.
-                                  type: string
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this IPv6 address range. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
-                                  type: string
-                              required:
-                                - cidrIPv6
-                              type: object
-                            type: array
-                          prefixListIds:
-                            description:
-                              "PrefixListIDs for an AWS service. With outbound
-                              rules, this is the AWS service to access through a VPC
-                              endpoint from instances associated with the security group.
-                              \n [VPC only]"
-                            items:
-                              description: PrefixListID describes a prefix list ID.
-                              properties:
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this prefix list ID. \n Constraints:
-                                    Up to 255 characters in length. Allowed characters
-                                    are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
-                                  type: string
-                                prefixListId:
-                                  description: The ID of the prefix.
-                                  type: string
-                              required:
-                                - prefixListId
-                              type: object
-                            type: array
-                          toPort:
-                            description:
-                              The end of port range for the TCP and UDP protocols,
-                              or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
-                              codes. If you specify all ICMP/ICMPv6 types, you must
-                              specify all codes.
-                            format: int32
-                            type: integer
-                          userIdGroupPairs:
-                            description:
-                              UserIDGroupPairs are the source security group
-                              and AWS account ID pairs. It contains one or more accounts
-                              and security groups to allow flows from security groups
-                              of other accounts.
-                            items:
-                              description:
-                                UserIDGroupPair describes a security group
-                                and AWS account ID pair.
-                              properties:
-                                description:
-                                  description:
-                                    "A description for the security group
-                                    rule that references this user ID group pair. \n
-                                    Constraints: Up to 255 characters in length. Allowed
-                                    characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
-                                  type: string
-                                groupId:
-                                  description: The ID of the security group.
-                                  type: string
-                                groupName:
-                                  description:
-                                    "The name of the security group. In a
-                                    request, use this parameter for a security group
-                                    in EC2-Classic or a default VPC only. For a security
-                                    group in a nondefault VPC, use the security group
-                                    ID. \n For a referenced security group in another
-                                    VPC, this value is not returned if the referenced
-                                    security group is deleted."
-                                  type: string
-                                userId:
-                                  description:
-                                    "The ID of an AWS account. \n For a referenced
-                                    security group in another VPC, the account ID of
-                                    the referenced security group is returned in the
-                                    response. If the referenced security group is deleted,
-                                    this value is not returned. \n [EC2-Classic] Required
-                                    when adding or removing rules that reference a security
-                                    group in another AWS account."
-                                  type: string
-                                vpcId:
-                                  description:
-                                    The ID of the VPC for the referenced
-                                    security group, if applicable.
-                                  type: string
-                                vpcIdRef:
-                                  description:
-                                    VPCIDRef reference a VPC to retrieve
-                                    its vpcId
-                                  properties:
-                                    name:
-                                      description: Name of the referenced object.
-                                      type: string
-                                  required:
-                                    - name
-                                  type: object
-                                vpcIdSelector:
-                                  description:
-                                    VPCIDSelector selects reference to a
-                                    VPC to retrieve its vpcId
-                                  properties:
-                                    matchControllerRef:
-                                      description:
-                                        MatchControllerRef ensures an object
-                                        with the same controller reference as the selecting
-                                        object is selected.
-                                      type: boolean
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description:
-                                        MatchLabels ensures an object with
-                                        matching labels is selected.
-                                      type: object
-                                  type: object
-                                vpcPeeringConnectionId:
-                                  description:
-                                    The ID of the VPC peering connection,
-                                    if applicable.
-                                  type: string
-                              type: object
-                            type: array
-                        required:
-                          - ipProtocol
-                        type: object
-                      type: array
-                    region:
-                      description:
-                        Region is the region you'd like your SecurityGroup
-                        to be created in.
-                      type: string
-                    tags:
-                      description: Tags represents to current ec2 tags.
-                      items:
-                        description: Tag defines a tag
-                        properties:
-                          key:
-                            description: Key is the name of the tag.
-                            type: string
-                          value:
-                            description: Value is the value of the tag.
-                            type: string
-                        required:
-                          - key
-                          - value
-                        type: object
-                      type: array
-                    vpcId:
-                      description: VPCID is the ID of the VPC.
-                      type: string
-                    vpcIdRef:
-                      description: VPCIDRef references a VPC to and retrieves its vpcId
+                        IPPermission Describes a set of permissions for
+                        a security group rule.
                       properties:
-                        name:
-                          description: Name of the referenced object.
+                        fromPort:
+                          description:
+                            The start of port range for the TCP and UDP
+                            protocols, or an ICMP/ICMPv6 type number. A value of -1
+                            indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
+                            types, you must specify all codes.
+                          format: int32
+                          type: integer
+                        ipProtocol:
+                          description:
+                            "The IP protocol name (tcp, udp, icmp, icmpv6)
+                            or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
+                            \n [VPC only] Use -1 to specify all protocols. When authorizing
+                            security group rules, specifying -1 or a protocol number
+                            other than tcp, udp, icmp, or icmpv6 allows traffic on
+                            all ports, regardless of any port range you specify. For
+                            tcp, udp, and icmp, you must specify a port range. For
+                            icmpv6, the port range is optional; if you omit the port
+                            range, traffic for all types and codes is allowed."
+                          type: string
+                        ipRanges:
+                          description: The IPv4 ranges.
+                          items:
+                            description: IPRange describes an IPv4 range.
+                            properties:
+                              cidrIp:
+                                description:
+                                  The IPv4 CIDR range. You can either specify
+                                  a CIDR range or a source security group, not both.
+                                  To specify a single IPv4 address, use the /32 prefix
+                                  length.
+                                type: string
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this IPv4 address range. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                type: string
+                            required:
+                              - cidrIp
+                            type: object
+                          type: array
+                        ipv6Ranges:
+                          description: "The IPv6 ranges. \n [VPC only]"
+                          items:
+                            description: IPv6Range describes an IPv6 range.
+                            properties:
+                              cidrIPv6:
+                                description:
+                                  The IPv6 CIDR range. You can either specify
+                                  a CIDR range or a source security group, not both.
+                                  To specify a single IPv6 address, use the /128 prefix
+                                  length.
+                                type: string
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this IPv6 address range. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                type: string
+                            required:
+                              - cidrIPv6
+                            type: object
+                          type: array
+                        prefixListIds:
+                          description:
+                            "PrefixListIDs for an AWS service. With outbound
+                            rules, this is the AWS service to access through a VPC
+                            endpoint from instances associated with the security group.
+                            \n [VPC only]"
+                          items:
+                            description: PrefixListID describes a prefix list ID.
+                            properties:
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this prefix list ID. \n Constraints:
+                                  Up to 255 characters in length. Allowed characters
+                                  are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                type: string
+                              prefixListId:
+                                description: The ID of the prefix.
+                                type: string
+                            required:
+                              - prefixListId
+                            type: object
+                          type: array
+                        toPort:
+                          description:
+                            The end of port range for the TCP and UDP protocols,
+                            or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
+                            codes. If you specify all ICMP/ICMPv6 types, you must
+                            specify all codes.
+                          format: int32
+                          type: integer
+                        userIdGroupPairs:
+                          description:
+                            UserIDGroupPairs are the source security group
+                            and AWS account ID pairs. It contains one or more accounts
+                            and security groups to allow flows from security groups
+                            of other accounts.
+                          items:
+                            description:
+                              UserIDGroupPair describes a security group
+                              and AWS account ID pair.
+                            properties:
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this user ID group pair. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                type: string
+                              groupId:
+                                description: The ID of the security group.
+                                type: string
+                              groupName:
+                                description:
+                                  "The name of the security group. In a
+                                  request, use this parameter for a security group
+                                  in EC2-Classic or a default VPC only. For a security
+                                  group in a nondefault VPC, use the security group
+                                  ID. \n For a referenced security group in another
+                                  VPC, this value is not returned if the referenced
+                                  security group is deleted."
+                                type: string
+                              userId:
+                                description:
+                                  "The ID of an AWS account. \n For a referenced
+                                  security group in another VPC, the account ID of
+                                  the referenced security group is returned in the
+                                  response. If the referenced security group is deleted,
+                                  this value is not returned. \n [EC2-Classic] Required
+                                  when adding or removing rules that reference a security
+                                  group in another AWS account."
+                                type: string
+                              vpcId:
+                                description:
+                                  The ID of the VPC for the referenced
+                                  security group, if applicable.
+                                type: string
+                              vpcIdRef:
+                                description:
+                                  VPCIDRef reference a VPC to retrieve
+                                  its vpcId
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              vpcIdSelector:
+                                description:
+                                  VPCIDSelector selects reference to a
+                                  VPC to retrieve its vpcId
+                                properties:
+                                  matchControllerRef:
+                                    description:
+                                      MatchControllerRef ensures an object
+                                      with the same controller reference as the selecting
+                                      object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                type: object
+                              vpcPeeringConnectionId:
+                                description:
+                                  The ID of the VPC peering connection,
+                                  if applicable.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                        - ipProtocol
+                      type: object
+                    type: array
+                  groupName:
+                    description: The name of the security group.
+                    type: string
+                  ingress:
+                    description:
+                      One or more inbound rules associated with the security
+                      group.
+                    items:
+                      description:
+                        IPPermission Describes a set of permissions for
+                        a security group rule.
+                      properties:
+                        fromPort:
+                          description:
+                            The start of port range for the TCP and UDP
+                            protocols, or an ICMP/ICMPv6 type number. A value of -1
+                            indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6
+                            types, you must specify all codes.
+                          format: int32
+                          type: integer
+                        ipProtocol:
+                          description:
+                            "The IP protocol name (tcp, udp, icmp, icmpv6)
+                            or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
+                            \n [VPC only] Use -1 to specify all protocols. When authorizing
+                            security group rules, specifying -1 or a protocol number
+                            other than tcp, udp, icmp, or icmpv6 allows traffic on
+                            all ports, regardless of any port range you specify. For
+                            tcp, udp, and icmp, you must specify a port range. For
+                            icmpv6, the port range is optional; if you omit the port
+                            range, traffic for all types and codes is allowed."
+                          type: string
+                        ipRanges:
+                          description: The IPv4 ranges.
+                          items:
+                            description: IPRange describes an IPv4 range.
+                            properties:
+                              cidrIp:
+                                description:
+                                  The IPv4 CIDR range. You can either specify
+                                  a CIDR range or a source security group, not both.
+                                  To specify a single IPv4 address, use the /32 prefix
+                                  length.
+                                type: string
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this IPv4 address range. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                type: string
+                            required:
+                              - cidrIp
+                            type: object
+                          type: array
+                        ipv6Ranges:
+                          description: "The IPv6 ranges. \n [VPC only]"
+                          items:
+                            description: IPv6Range describes an IPv6 range.
+                            properties:
+                              cidrIPv6:
+                                description:
+                                  The IPv6 CIDR range. You can either specify
+                                  a CIDR range or a source security group, not both.
+                                  To specify a single IPv6 address, use the /128 prefix
+                                  length.
+                                type: string
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this IPv6 address range. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=&;{}!$*"
+                                type: string
+                            required:
+                              - cidrIPv6
+                            type: object
+                          type: array
+                        prefixListIds:
+                          description:
+                            "PrefixListIDs for an AWS service. With outbound
+                            rules, this is the AWS service to access through a VPC
+                            endpoint from instances associated with the security group.
+                            \n [VPC only]"
+                          items:
+                            description: PrefixListID describes a prefix list ID.
+                            properties:
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this prefix list ID. \n Constraints:
+                                  Up to 255 characters in length. Allowed characters
+                                  are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                type: string
+                              prefixListId:
+                                description: The ID of the prefix.
+                                type: string
+                            required:
+                              - prefixListId
+                            type: object
+                          type: array
+                        toPort:
+                          description:
+                            The end of port range for the TCP and UDP protocols,
+                            or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6
+                            codes. If you specify all ICMP/ICMPv6 types, you must
+                            specify all codes.
+                          format: int32
+                          type: integer
+                        userIdGroupPairs:
+                          description:
+                            UserIDGroupPairs are the source security group
+                            and AWS account ID pairs. It contains one or more accounts
+                            and security groups to allow flows from security groups
+                            of other accounts.
+                          items:
+                            description:
+                              UserIDGroupPair describes a security group
+                              and AWS account ID pair.
+                            properties:
+                              description:
+                                description:
+                                  "A description for the security group
+                                  rule that references this user ID group pair. \n
+                                  Constraints: Up to 255 characters in length. Allowed
+                                  characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+                                type: string
+                              groupId:
+                                description: The ID of the security group.
+                                type: string
+                              groupName:
+                                description:
+                                  "The name of the security group. In a
+                                  request, use this parameter for a security group
+                                  in EC2-Classic or a default VPC only. For a security
+                                  group in a nondefault VPC, use the security group
+                                  ID. \n For a referenced security group in another
+                                  VPC, this value is not returned if the referenced
+                                  security group is deleted."
+                                type: string
+                              userId:
+                                description:
+                                  "The ID of an AWS account. \n For a referenced
+                                  security group in another VPC, the account ID of
+                                  the referenced security group is returned in the
+                                  response. If the referenced security group is deleted,
+                                  this value is not returned. \n [EC2-Classic] Required
+                                  when adding or removing rules that reference a security
+                                  group in another AWS account."
+                                type: string
+                              vpcId:
+                                description:
+                                  The ID of the VPC for the referenced
+                                  security group, if applicable.
+                                type: string
+                              vpcIdRef:
+                                description:
+                                  VPCIDRef reference a VPC to retrieve
+                                  its vpcId
+                                properties:
+                                  name:
+                                    description: Name of the referenced object.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              vpcIdSelector:
+                                description:
+                                  VPCIDSelector selects reference to a
+                                  VPC to retrieve its vpcId
+                                properties:
+                                  matchControllerRef:
+                                    description:
+                                      MatchControllerRef ensures an object
+                                      with the same controller reference as the selecting
+                                      object is selected.
+                                    type: boolean
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      MatchLabels ensures an object with
+                                      matching labels is selected.
+                                    type: object
+                                type: object
+                              vpcPeeringConnectionId:
+                                description:
+                                  The ID of the VPC peering connection,
+                                  if applicable.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                        - ipProtocol
+                      type: object
+                    type: array
+                  region:
+                    description:
+                      Region is the region you'd like your SecurityGroup
+                      to be created in.
+                    type: string
+                  tags:
+                    description: Tags represents to current ec2 tags.
+                    items:
+                      description: Tag defines a tag
+                      properties:
+                        key:
+                          description: Key is the name of the tag.
+                          type: string
+                        value:
+                          description: Value is the value of the tag.
                           type: string
                       required:
-                        - name
+                        - key
+                        - value
                       type: object
-                    vpcIdSelector:
-                      description:
-                        VPCIDSelector selects a reference to a VPC to and
-                        retrieves its vpcId
-                      properties:
-                        matchControllerRef:
-                          description:
-                            MatchControllerRef ensures an object with the
-                            same controller reference as the selecting object is selected.
-                          type: boolean
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description:
-                            MatchLabels ensures an object with matching labels
-                            is selected.
-                          type: object
-                      type: object
-                  required:
-                    - description
-                    - groupName
+                    type: array
+                  vpcId:
+                    description: VPCID is the ID of the VPC.
+                    type: string
+                  vpcIdRef:
+                    description: VPCIDRef references a VPC to and retrieves its vpcId
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  vpcIdSelector:
+                    description:
+                      VPCIDSelector selects a reference to a VPC to and
+                      retrieves its vpcId
+                    properties:
+                      matchControllerRef:
+                        description:
+                          MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description:
+                          MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
+                required:
+                  - description
+                  - groupName

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -4,7 +4,7 @@ metadata:
   name: xawssecuritygroups.network.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awssecuritygroups.network.crossplane.dfds.cloud
+    name: xawssecuritygroups.network.crossplane.dfds.cloud
   group: network.crossplane.dfds.cloud
   names:
     kind: XAWSSecurityGroup


### PR DESCRIPTION
- [x] composition names updated so it can be used as default by XRDs instead of redundant compositionSelection labels
- [x] Status field info added on all composition
- [x] external names added to support importing existing resources
- [x] added support for orphaning resources to support "detaching" resources from kubernetes
- [x] minor fix to example claims
- [x] Still missing review and test of IAM resource. Need to be renamed to follow naming conventions
 