### PR TITLE
reconcile status info added to claims

### DIFF
--- a/package/aws/README.md
+++ b/package/aws/README.md
@@ -99,19 +99,40 @@ Next in the file, we should declare a version for our resource and lay out the s
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime    
     schema:
       openAPIV3Schema:
         type: object
         properties:
-          spec:
+          status:
             type: object
             properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  bucket:
+                    description: Name of the provisioned bucket
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true        
+          spec:
+            type: object
+            parameters:
               parameters:
                 type: object
                 properties:
 ```
 
-We should then add properties of the resources under the third `properties:` we defined above. We can copy and paste
+We should then add properties of the resources under `schema.openAPIV3Schema.spec.parameters.parameters.properties:` we defined above. We can copy and paste
 these from the source code of the resource in aws-provider (using the desired release tag). For example, https://raw.githubusercontent.com/crossplane/provider-aws/master/package/crds/s3.aws.crossplane.io_buckets.yaml and copy the forProvider.properties. The full list of resource source code can be found here: https://github.com/crossplane/provider-aws/tree/master/package/crds (make sure to select the correct tag for our current version specified in
 `package/crossplane.yaml` from the github dropdown)
 
@@ -129,6 +150,10 @@ deletionPolicy:
   type: string
   default: "Delete" 
 ```
+*Note:* The additionalPrinterColumns section allows adding custom columns with additional information available for the user on `kubectl get` requests 
+
+In the status field under `schema.openAPIV3Schema.spec` we add custom fields to view additional information about the created resources when user do `kubectl describe` on the claim resource.
+
 ### Create a composition.yaml
 
 The file should be composed with the following section to define the composition. We will continue to use bucket as our example:
@@ -186,10 +211,15 @@ We must then define our resource for depoyment. Firstly, our bucket resource and
     - type: FromCompositeFieldPath
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
     - fromFieldPath: spec.parameters.deletionPolicy
-      toFieldPath: spec.deletionPolicy      
+      toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional         
 ```
 Note that the patches apply our configname patchset from above. In addition, we patch the parameters defined in our definition.yaml through to this resource type by applying it to spec.forProvider. We also produce a status output that will show the raw resource name when you describe the XRD.
-One more important thing to notice about metada annotation mapping is that we are enabling reading external name from claims using metada.annotation property like in the following example claim:
+One more important thing to notice about metada annotation mapping is that we are enabling reading external name from claims using metadata.annotation property like in the following example claim:
 ```
 apiVersion: storage.crossplane.dfds.cloud/v1alpha1
 kind: AWSBucket
@@ -204,7 +234,9 @@ spec:
     acl: public-read
 ```
 This enables users to import resources into Crossplane to start managing them using kubernetes.
-While this can be the way for attaching existing resources, the following deletionPolicy patch with the value Orphan passed in claim will "detach" a resource from kubernetes in case of the claim have been deleted.
+While this can be the way for attaching existing resources, the following deletionPolicy patch with the value Orphan that can be passed in the claim will "detach" a resource from kubernetes in case of the claim have been deleted. So this will basically keep resources on AWS if there is a need for it.
+
+The last patch field mapping will copy status information from the managed resource and them available in the composite resource and the claim under a new field called instance conditions. It will also allow additionalPrinterCol
  
 Finally, we need to define our rbac resource. We need to pass the appropriate values from our bucket resource into the `resourceTypes` and `apiGroups` attributes. Our resourceType is `buckets`, which is a plural version of the `kind` and the API group for it is `s3.aws.crossplane.io` which we can get from `apiVersion` of the bucket resource.
 

--- a/package/aws/bucket/composition.yaml
+++ b/package/aws/bucket/composition.yaml
@@ -63,3 +63,8 @@ spec:
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]" # enables using external name in claims      
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional

--- a/package/aws/bucket/definition.yaml
+++ b/package/aws/bucket/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime
     schema:
       openAPIV3Schema:
         type: object
@@ -33,7 +40,7 @@ spec:
                   rbac:
                     description: list of the provisioned RBAC resources
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true                    
+                    x-kubernetes-preserve-unknown-fields: true
           spec:
             type: object
             properties:

--- a/package/aws/containerregistry/composition.yaml
+++ b/package/aws/containerregistry/composition.yaml
@@ -69,6 +69,11 @@ spec:
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]" # enables using external name in claims      
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional      
 
   - name: ecr-policy
     base:

--- a/package/aws/containerregistry/definition.yaml
+++ b/package/aws/containerregistry/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime    
     schema:
       openAPIV3Schema:
         type: object

--- a/package/aws/iamrole/composition.yaml
+++ b/package/aws/iamrole/composition.yaml
@@ -37,7 +37,12 @@ spec:
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
     - fromFieldPath: spec.parameters.deletionPolicy
       toFieldPath: spec.deletionPolicy 
-            
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional
+                    
   - name: rbac
     base:
       apiVersion: crossplane.dfds.cloud/v1alpha1

--- a/package/aws/iamrole/definition.yaml
+++ b/package/aws/iamrole/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime     
     schema:
       openAPIV3Schema:
         type: object

--- a/package/aws/iamrolepolicyattachement/composition.yaml
+++ b/package/aws/iamrolepolicyattachement/composition.yaml
@@ -59,4 +59,9 @@ spec:
       toFieldPath: spec.deletionPolicy
     - type: ToCompositeFieldPath
       fromFieldPath: "metadata.name"
-      toFieldPath: "status.createdResources.iamrolepolicyattachement"           
+      toFieldPath: "status.createdResources.iamrolepolicyattachement"
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional

--- a/package/aws/iamrolepolicyattachement/definition.yaml
+++ b/package/aws/iamrolepolicyattachement/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime
     schema:
       openAPIV3Schema:
         type: object
@@ -33,7 +40,14 @@ spec:
                   rbac:
                     description: list of the provisioned RBAC resources
                     type: object
-                    x-kubernetes-preserve-unknown-fields: true                   
+                    x-kubernetes-preserve-unknown-fields: true
+              instanceConditions:
+                description: >
+                  Information about the managed resource condition, e.g. reconcile errors due to bad parameters
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true                                            
           spec:
             description: An RolePolicyAttachmentSpec defines the desired state of
               an RolePolicyAttachment.          

--- a/package/aws/queue/composition.yaml
+++ b/package/aws/queue/composition.yaml
@@ -64,4 +64,9 @@ spec:
     - type: FromCompositeFieldPath
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
     - fromFieldPath: spec.parameters.deletionPolicy
-      toFieldPath: spec.deletionPolicy         
+      toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional       

--- a/package/aws/queue/definition.yaml
+++ b/package/aws/queue/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime    
     schema:
       openAPIV3Schema:
         type: object

--- a/package/aws/replicationgroup/compostion.yaml
+++ b/package/aws/replicationgroup/compostion.yaml
@@ -62,4 +62,9 @@ spec:
     - type: FromCompositeFieldPath
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
     - fromFieldPath: spec.parameters.deletionPolicy
-      toFieldPath: spec.deletionPolicy         
+      toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional      

--- a/package/aws/replicationgroup/definition.yaml
+++ b/package/aws/replicationgroup/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime    
     schema:
       openAPIV3Schema:
         type: object

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -62,4 +62,9 @@ spec:
     - type: FromCompositeFieldPath
       fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
     - fromFieldPath: spec.parameters.deletionPolicy
-      toFieldPath: spec.deletionPolicy           
+      toFieldPath: spec.deletionPolicy
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional             

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -16,6 +16,13 @@ spec:
   - name: v1alpha1
     served: true
     referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime
     schema:
       openAPIV3Schema:
         type: object

--- a/package/sqldatabases/definition.yaml
+++ b/package/sqldatabases/definition.yaml
@@ -139,7 +139,7 @@ spec:
     additionalPrinterColumns:
     - name: Synced
       type: string
-      jsonPath: ".status.dbInstanceConditions[0].status"
-    - name: Last Sync Date
+      jsonPath: .status.dbInstanceConditions[?(@.type=='Synced')].status
+    - name: Last Change
       type: string
-      jsonPath: ".status.dbInstanceConditions[0].lastTransitionTime"
+      jsonPath: .status.dbInstanceConditions[?(@.type=='Synced')].lastTransitionTime


### PR DESCRIPTION
Allow viewing reconcile status like error messages and transition dates from the underlying managed resource in the claims
- update composition files to include instanceConditions in the status field of each XR
- additionalPrinterColumns added to the XRDs
