### PR TITLE
Feature/certificateauthority rbac

### DIFF
--- a/examples/aws/certificate/certificateclaim.yaml
+++ b/examples/aws/certificate/certificateclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+apiVersion: certs.crossplane.dfds.cloud/v1alpha1
 kind: AWSCertificate
 metadata:
   name: awscertificatedfds

--- a/examples/aws/certificateauthority/certificateauthorityclaim.yaml
+++ b/examples/aws/certificateauthority/certificateauthorityclaim.yaml
@@ -1,0 +1,24 @@
+apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+kind: AWSCertificateAuthority
+metadata:
+  name: awscertificateauthoritydfds
+  namespace: my-namespace
+spec:
+  parameters:
+    region: us-east-1
+    permanentDeletionTimeInDays: 7
+    type: ROOT
+    status: ACTIVE
+    certificateAuthorityConfiguration:
+      keyAlgorithm: RSA_2048
+      signingAlgorithm: SHA256WITHRSA
+      subject:
+        commonName: ca.dfds.cloud
+        country: GB
+        locality: dfdsexample
+        organization: dfdsexample
+        organizationalUnit: dfdsexample
+        state: dfdsexample
+    tags:
+    - key: Name
+      value: dfdsexample

--- a/examples/aws/certificateauthority/certificateauthorityclaim.yaml
+++ b/examples/aws/certificateauthority/certificateauthorityclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+apiVersion: certs.crossplane.dfds.cloud/v1alpha1
 kind: AWSCertificateAuthority
 metadata:
   name: awscertificateauthoritydfds

--- a/examples/kubernetesproviderconfig.yaml
+++ b/examples/kubernetesproviderconfig.yaml
@@ -1,8 +1,12 @@
 # Make sure provider-kubernetes has enough permissions to install your objects into cluster
 #
 # You can give admin permissions by running:
+#
 # SA=$(kubectl -n crossplane-system get sa -o name | grep provider-kubernetes | sed -e 's|serviceaccount\/|crossplane-system:|g')
 # kubectl create clusterrolebinding provider-kubernetes-admin-binding --clusterrole cluster-admin --serviceaccount="${SA}"
+#
+# Alternatively, for Upbound UXP you may need to replace "crossplane-system" with "upbound-system" in the above commands
+
 apiVersion: kubernetes.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:

--- a/package/aws/certificate/composition.yaml
+++ b/package/aws/certificate/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawscertificates.certificates.crossplane.dfds.cloud
+  name: xawscertificates.certs.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+    apiVersion: certs.crossplane.dfds.cloud/v1alpha1
     kind: XAWSCertificate
 
   patchSets:

--- a/package/aws/certificate/definition.yaml
+++ b/package/aws/certificate/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawscertificates.certificates.crossplane.dfds.cloud
+  name: xawscertificates.certs.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawscertificates.certificates.crossplane.dfds.cloud
-  group: certificates.crossplane.dfds.cloud
+    name: xawscertificates.certs.crossplane.dfds.cloud
+  group: certs.crossplane.dfds.cloud
   names:
     kind: XAWSCertificate
     plural: xawscertificates

--- a/package/aws/certificateauthority/composition.yaml
+++ b/package/aws/certificateauthority/composition.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
+  labels:
+    provider: aws
+spec:
+  compositeTypeRef:
+    apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+    kind: XAWSCertificateAuthority
+
+  patchSets:
+  - name: configname
+    patches:
+    - fromFieldPath: spec.claimRef.namespace
+      toFieldPath: spec.providerConfigRef.name
+      transforms:
+      - type: string
+        string:
+          fmt: "%s-aws"
+      policy:
+        fromFieldPath: Required
+  resources:
+  - name: certificateauthority
+    base:
+      apiVersion: acmpca.aws.crossplane.io/v1beta1
+      kind: CertificateAuthority
+      spec:
+        forProvider:
+          region: eu-west-1
+    patches:
+    - type: PatchSet
+      patchSetName: configname
+    - fromFieldPath: spec.parameters
+      toFieldPath: spec.forProvider
+    - type: ToCompositeFieldPath
+      fromFieldPath: "metadata.name"
+      toFieldPath: "status.createdResources.certificateauthority"
+    - type: FromCompositeFieldPath
+      fromFieldPath: "metadata.annotations[crossplane.io/external-name]"
+    - fromFieldPath: spec.parameters.deletionPolicy
+      toFieldPath: spec.deletionPolicy    
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.conditions
+      toFieldPath: status.instanceConditions
+      policy:
+        fromFieldPath: Optional
+
+  - name: rbac
+    base:
+      apiVersion: crossplane.dfds.cloud/v1alpha1
+      kind: XRBAC
+      spec:
+        resourceTypes:
+        - certificateauthorities
+        apiGroups:
+        - certificateauthorities.acmpca.aws.crossplane.io
+        providerConfigRef:
+          name: kubernetes-provider
+    patches:
+    - fromFieldPath: metadata.name
+      toFieldPath: spec.resourceName
+    - fromFieldPath: spec.claimRef.namespace
+      toFieldPath: spec.resourceNamespace
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.createdResources
+      toFieldPath: status.createdResources.rbac
+      policy:
+        fromFieldPath: Optional

--- a/package/aws/certificateauthority/composition.yaml
+++ b/package/aws/certificateauthority/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
+  name: xawscertificateauthorities.certs.crossplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: certificates.crossplane.dfds.cloud/v1alpha1
+    apiVersion: certs.crossplane.dfds.cloud/v1alpha1
     kind: XAWSCertificateAuthority
 
   patchSets:

--- a/package/aws/certificateauthority/composition.yaml
+++ b/package/aws/certificateauthority/composition.yaml
@@ -54,7 +54,7 @@ spec:
         resourceTypes:
         - certificateauthorities
         apiGroups:
-        - certificateauthorities.acmpca.aws.crossplane.io
+        - acmpca.aws.crossplane.io
         providerConfigRef:
           name: kubernetes-provider
     patches:

--- a/package/aws/certificateauthority/definition.yaml
+++ b/package/aws/certificateauthority/definition.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
+spec:
+  defaultCompositionRef:
+    name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
+  group: certificates.crossplane.dfds.cloud
+  names:
+    kind: XAWSCertificateAuthority
+    plural: xawscertificateauthorities
+  claimNames:
+    kind: AWSCertificateAuthority
+    plural: awscertificateauthorities
+
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    additionalPrinterColumns:
+    - name: Synced
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].status    
+    - name: Last Change
+      type: string
+      jsonPath: .status.instanceConditions[?(@.type=='Synced')].lastTransitionTime
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            type: object
+            properties:
+              createdResources:
+                description: list of resources created for this claim
+                type: object
+                properties:
+                  certificate:
+                    description: Name of the provisioned certificate
+                    type: string
+                  rbac:
+                    description: list of the provisioned RBAC resources
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+              instanceConditions:
+                description: >
+                  Freeform field containing information about the instance condition, e.g. reconcile errors due to bad parameters
+                type: array
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true               
+          spec:
+            type: object
+            properties:
+              parameters:
+                type: object
+                properties:
+                  deletionPolicy: 
+                    description: Specify whether the actual cloud resource should be deleted when this managed resource is deleted in Kubernetes API server. Possible values are Delete (the default) and Orphan
+                    type: string
+                    default: "Delete"
+                  certificateAuthorityConfiguration:
+                    description: CertificateAuthorityConfiguration to associate with
+                      the certificateAuthority.
+                    properties:
+                      keyAlgorithm:
+                        description: Type of the public key algorithm
+                        enum:
+                        - RSA_2048
+                        - EC_secp384r1
+                        - EC_prime256v1
+                        - RSA_4096
+                        type: string
+                      signingAlgorithm:
+                        description: Algorithm that private CA uses to sign certificate
+                          requests
+                        enum:
+                        - SHA512WITHECDSA
+                        - SHA256WITHECDSA
+                        - SHA384WITHECDSA
+                        - SHA512WITHRSA
+                        - SHA256WITHRSA
+                        - SHA384WITHRSA
+                        type: string
+                      subject:
+                        description: Subject is information of Certificate Authority
+                        properties:
+                          commonName:
+                            description: FQDN associated with the certificate subject
+                            type: string
+                          country:
+                            description: Two-digit code that specifies the country
+                            type: string
+                          distinguishedNameQualifier:
+                            description: Disambiguating information for the certificate
+                              subject.
+                            type: string
+                          generationQualifier:
+                            description: Typically a qualifier appended to the name
+                              of an individual
+                            type: string
+                          givenName:
+                            description: First name
+                            type: string
+                          initials:
+                            description: Concatenation of first letter of the GivenName,
+                              Middle name and SurName.
+                            type: string
+                          locality:
+                            description: The locality such as a city or town
+                            type: string
+                          organization:
+                            description: Organization legal name
+                            type: string
+                          organizationalUnit:
+                            description: Organization's subdivision or unit
+                            type: string
+                          pseudonym:
+                            description: Shortened version of a longer GivenName
+                            type: string
+                          serialNumber:
+                            description: The certificate serial number.
+                            type: string
+                          state:
+                            description: State in which the subject of the certificate
+                              is located
+                            type: string
+                          surname:
+                            description: Surname
+                            type: string
+                          title:
+                            description: Title
+                            type: string
+                        required:
+                        - commonName
+                        - country
+                        - locality
+                        - organization
+                        - organizationalUnit
+                        - state
+                        type: object
+                    required:
+                    - keyAlgorithm
+                    - signingAlgorithm
+                    - subject
+                    type: object
+                  permanentDeletionTimeInDays:
+                    description: The number of days to make a CA restorable after
+                      it has been deleted
+                    format: int32
+                    type: integer
+                  region:
+                    description: Region is the region you'd like your CertificateAuthority
+                      to be created in.
+                    type: string
+                  revocationConfiguration:
+                    description: RevocationConfiguration to associate with the certificateAuthority.
+                    properties:
+                      customCname:
+                        description: Alias for the CRL distribution point
+                        type: string
+                      enabled:
+                        description: Boolean value that specifies certificate revocation
+                        type: boolean
+                      expirationInDays:
+                        description: Number of days until a certificate expires
+                        format: int32
+                        type: integer
+                      s3BucketName:
+                        description: Name of the S3 bucket that contains the CRL
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  status:
+                    description: Status of the certificate authority. This value cannot
+                      be configured at creation, but can be updated to set a CA to
+                      ACTIVE or DISABLED.
+                    enum:
+                    - ACTIVE
+                    - DISABLED
+                    type: string
+                  tags:
+                    description: One or more resource tags to associate with the certificateAuthority.
+                    items:
+                      description: Tag represents user-provided metadata that can
+                        be associated
+                      properties:
+                        key:
+                          description: The key name that can be used to look up or
+                            retrieve the associated value.
+                          type: string
+                        value:
+                          description: The value associated with this tag.
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  type:
+                    description: Type of the certificate authority
+                    enum:
+                    - ROOT
+                    - SUBORDINATE
+                    type: string
+                required:
+                - certificateAuthorityConfiguration
+                - region
+                - tags
+                - type

--- a/package/aws/certificateauthority/definition.yaml
+++ b/package/aws/certificateauthority/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
+  name: xawscertificateauthorities.certs.crossplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawscertificateauthorities.certificates.crossplane.dfds.cloud
-  group: certificates.crossplane.dfds.cloud
+    name: xawscertificateauthorities.certs.crossplane.dfds.cloud
+  group: certs.crossplane.dfds.cloud
   names:
     kind: XAWSCertificateAuthority
     plural: xawscertificateauthorities


### PR DESCRIPTION
This PR adds the AWSCertificateAuthority resource. It also changes the certificates namespace from certificates.crossplane.dfds.cloud to certs.crossplane.dfds.cloud to work around 63 character resource limit would occur with certificateauthoritypermissions.certificates.crossplane.dfds.cloud