### PR TITLE
rename apigroup to xplane

### DIFF
--- a/examples/aws/bucket/bucketclaim.yaml
+++ b/examples/aws/bucket/bucketclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.crossplane.dfds.cloud/v1alpha1
+apiVersion: storage.xplane.dfds.cloud/v1alpha1
 kind: AWSBucket
 metadata:
   name: awsbucketdfds

--- a/examples/aws/certificate/certificateclaim.yaml
+++ b/examples/aws/certificate/certificateclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+apiVersion: certs.xplane.dfds.cloud/v1alpha1
 kind: AWSCertificate
 metadata:
   name: awscertificatedfds

--- a/examples/aws/certificateauthority/certificateauthorityclaim.yaml
+++ b/examples/aws/certificateauthority/certificateauthorityclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+apiVersion: certs.xplane.dfds.cloud/v1alpha1
 kind: AWSCertificateAuthority
 metadata:
   name: awscertificateauthoritydfds

--- a/examples/aws/certificateauthoritypermission/certificiateauthoritypermissionclaim.yaml
+++ b/examples/aws/certificateauthoritypermission/certificiateauthoritypermissionclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+apiVersion: certs.xplane.dfds.cloud/v1alpha1
 kind: AWSCertificateAuthorityPermission
 metadata:
   name: dfdsexample

--- a/examples/aws/queue/queueclaim.yaml
+++ b/examples/aws/queue/queueclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.crossplane.dfds.cloud/v1alpha1
+apiVersion: messaging.xplane.dfds.cloud/v1alpha1
 kind: AWSQueue
 metadata:
   name: sqsdfds

--- a/examples/aws/replicationgroup/replicationgroupclaim.yaml
+++ b/examples/aws/replicationgroup/replicationgroupclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: cache.crossplane.dfds.cloud/v1alpha1
+apiVersion: cache.xplane.dfds.cloud/v1alpha1
 kind: AWSReplicationGroup
 metadata:
   name: replicationgroupdfds

--- a/examples/aws/role/roleclaim.yaml
+++ b/examples/aws/role/roleclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: identity.crossplane.dfds.cloud/v1alpha1
+apiVersion: identity.xplane.dfds.cloud/v1alpha1
 kind: AWSRole
 metadata:
   name: identitydfds

--- a/examples/aws/rolepolicyattachement/rolepolicyattachmentclaim.yaml
+++ b/examples/aws/rolepolicyattachement/rolepolicyattachmentclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: identity.crossplane.dfds.cloud/v1alpha1
+apiVersion: identity.xplane.dfds.cloud/v1alpha1
 kind: AWSRolePolicyAttachment
 metadata:
   name: s3-readonly-dfds

--- a/examples/aws/securitygroup/securitygroupclaim.yaml
+++ b/examples/aws/securitygroup/securitygroupclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: network.crossplane.dfds.cloud/v1alpha1
+apiVersion: network.xplane.dfds.cloud/v1alpha1
 kind: AWSSecurityGroup
 metadata:
   name: securitygrouptestdfds

--- a/examples/containerregistry/containerregistryclaim.yaml
+++ b/examples/containerregistry/containerregistryclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.dfds.cloud/v1alpha1
+apiVersion: xplane.dfds.cloud/v1alpha1
 kind: ContainerRegistry
 metadata:
   namespace: my-namespace

--- a/examples/sqldatabases/claim-dynamic-nonproduction.yaml
+++ b/examples/sqldatabases/claim-dynamic-nonproduction.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.dfds.cloud/v1alpha1
+apiVersion: xplane.dfds.cloud/v1alpha1
 kind: SqlDatabaseInstance
 metadata:
   namespace: my-namespace

--- a/examples/sqldatabases/claim-dynamic-production.yaml
+++ b/examples/sqldatabases/claim-dynamic-production.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.dfds.cloud/v1alpha1
+apiVersion: xplane.dfds.cloud/v1alpha1
 kind: SqlDatabaseInstance
 metadata:
   namespace: my-namespace

--- a/package/aws/README.md
+++ b/package/aws/README.md
@@ -55,7 +55,7 @@ We use the following naming conventions in our RBAC Wrapper compositions.
 
 #### Namespace
 
-Our namespace must be [group].crossplane.dfds.cloud. [group] should be a generic descriptive category such as:
+Our namespace must be [group].xplane.dfds.cloud. [group] should be a generic descriptive category such as:
 
 - storage
 - networking
@@ -79,11 +79,11 @@ our example:
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsbuckets.storage.crossplane.dfds.cloud
+  name: xawsbuckets.storage.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: awsbuckets.storage.crossplane.dfds.cloud
-  group: storage.crossplane.dfds.cloud
+    name: awsbuckets.storage.xplane.dfds.cloud
+  group: storage.xplane.dfds.cloud
   names:
     kind: XAWSBucket
     plural: xawsbuckets
@@ -169,12 +169,12 @@ The file should be composed with the following section to define the composition
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsbuckets.storage.crossplane.dfds.cloud
+  name: xawsbuckets.storage.xplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: storage.crossplane.dfds.cloud/v1alpha1
+    apiVersion: storage.xplane.dfds.cloud/v1alpha1
     kind: XAWSBucket
 ```
 
@@ -228,7 +228,7 @@ We must then define our resource for depoyment. Firstly, our bucket resource and
 Note that the patches apply our configname patchset from above. In addition, we patch the parameters defined in our definition.yaml through to this resource type by applying it to spec.forProvider. We also produce a status output that will show the raw resource name when you describe the XRD.
 One more important thing to notice about metada annotation mapping is that we are enabling reading external name from claims using metadata.annotation property like in the following example claim:
 ```
-apiVersion: storage.crossplane.dfds.cloud/v1alpha1
+apiVersion: storage.xplane.dfds.cloud/v1alpha1
 kind: AWSBucket
 metadata:
   name: awsbucketdfds
@@ -250,7 +250,7 @@ Finally, we need to define our rbac resource. We need to pass the appropriate va
 ```
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/bucket/composition.yaml
+++ b/package/aws/bucket/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsbuckets.storage.crossplane.dfds.cloud  
+  name: xawsbuckets.storage.xplane.dfds.cloud  
 spec:
   compositeTypeRef:
-    apiVersion: storage.crossplane.dfds.cloud/v1alpha1
+    apiVersion: storage.xplane.dfds.cloud/v1alpha1
     kind: XAWSBucket
 
   patchSets:
@@ -22,7 +22,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes: 

--- a/package/aws/bucket/definition.yaml
+++ b/package/aws/bucket/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsbuckets.storage.crossplane.dfds.cloud
+  name: xawsbuckets.storage.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawsbuckets.storage.crossplane.dfds.cloud 
-  group: storage.crossplane.dfds.cloud
+    name: xawsbuckets.storage.xplane.dfds.cloud 
+  group: storage.xplane.dfds.cloud
   names:
     kind: XAWSBucket
     plural: xawsbuckets

--- a/package/aws/certificate/composition.yaml
+++ b/package/aws/certificate/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawscertificates.certs.crossplane.dfds.cloud
+  name: xawscertificates.certs.xplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+    apiVersion: certs.xplane.dfds.cloud/v1alpha1
     kind: XAWSCertificate
 
   patchSets:
@@ -48,7 +48,7 @@ spec:
 
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/certificate/definition.yaml
+++ b/package/aws/certificate/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawscertificates.certs.crossplane.dfds.cloud
+  name: xawscertificates.certs.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawscertificates.certs.crossplane.dfds.cloud
-  group: certs.crossplane.dfds.cloud
+    name: xawscertificates.certs.xplane.dfds.cloud
+  group: certs.xplane.dfds.cloud
   names:
     kind: XAWSCertificate
     plural: xawscertificates

--- a/package/aws/certificateauthority/composition.yaml
+++ b/package/aws/certificateauthority/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawscertificateauthorities.certs.crossplane.dfds.cloud
+  name: xawscertificateauthorities.certs.xplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+    apiVersion: certs.xplane.dfds.cloud/v1alpha1
     kind: XAWSCertificateAuthority
 
   patchSets:
@@ -48,7 +48,7 @@ spec:
 
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/certificateauthority/definition.yaml
+++ b/package/aws/certificateauthority/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawscertificateauthorities.certs.crossplane.dfds.cloud
+  name: xawscertificateauthorities.certs.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawscertificateauthorities.certs.crossplane.dfds.cloud
-  group: certs.crossplane.dfds.cloud
+    name: xawscertificateauthorities.certs.xplane.dfds.cloud
+  group: certs.xplane.dfds.cloud
   names:
     kind: XAWSCertificateAuthority
     plural: xawscertificateauthorities

--- a/package/aws/certificateauthoritypermission/composition.yaml
+++ b/package/aws/certificateauthoritypermission/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawscertificateauthoritypermissions.certs.crossplane.dfds.cloud
+  name: xawscertificateauthoritypermissions.certs.xplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: certs.crossplane.dfds.cloud/v1alpha1
+    apiVersion: certs.xplane.dfds.cloud/v1alpha1
     kind: XAWSCertificateAuthorityPermission
 
   patchSets:
@@ -48,7 +48,7 @@ spec:
 
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/certificateauthoritypermission/definition.yaml
+++ b/package/aws/certificateauthoritypermission/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawscertificateauthoritypermissions.certs.crossplane.dfds.cloud
+  name: xawscertificateauthoritypermissions.certs.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawscertificateauthoritypermissions.certs.crossplane.dfds.cloud
-  group: certs.crossplane.dfds.cloud
+    name: xawscertificateauthoritypermissions.certs.xplane.dfds.cloud
+  group: certs.xplane.dfds.cloud
   names:
     kind: XAWSCertificateAuthorityPermission
     plural: xawscertificateauthoritypermissions

--- a/package/aws/queue/composition.yaml
+++ b/package/aws/queue/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsqueues.messaging.crossplane.dfds.cloud
+  name: xawsqueues.messaging.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: messaging.crossplane.dfds.cloud/v1alpha1
+    apiVersion: messaging.xplane.dfds.cloud/v1alpha1
     kind: XAWSQueue
 
   patchSets:
@@ -22,7 +22,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/queue/definition.yaml
+++ b/package/aws/queue/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsqueues.messaging.crossplane.dfds.cloud
+  name: xawsqueues.messaging.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawsqueues.messaging.crossplane.dfds.cloud
-  group: messaging.crossplane.dfds.cloud
+    name: xawsqueues.messaging.xplane.dfds.cloud
+  group: messaging.xplane.dfds.cloud
   names:
     kind: XAWSQueue
     plural: xawsqueues

--- a/package/aws/replicationgroup/compostion.yaml
+++ b/package/aws/replicationgroup/compostion.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsreplicationgroups.cache.crossplane.dfds.cloud
+  name: xawsreplicationgroups.cache.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: cache.crossplane.dfds.cloud/v1alpha1
+    apiVersion: cache.xplane.dfds.cloud/v1alpha1
     kind: XAWSReplicationGroup
   patchSets:
   - name: configname
@@ -20,7 +20,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes: 

--- a/package/aws/replicationgroup/definition.yaml
+++ b/package/aws/replicationgroup/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsreplicationgroups.cache.crossplane.dfds.cloud
+  name: xawsreplicationgroups.cache.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawsreplicationgroups.cache.crossplane.dfds.cloud
-  group: cache.crossplane.dfds.cloud
+    name: xawsreplicationgroups.cache.xplane.dfds.cloud
+  group: cache.xplane.dfds.cloud
   names:
     kind: XAWSReplicationGroup
     plural: xawsreplicationgroups

--- a/package/aws/role/composition.yaml
+++ b/package/aws/role/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsroles.identity.crossplane.dfds.cloud
+  name: xawsroles.identity.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: identity.crossplane.dfds.cloud/v1alpha1
+    apiVersion: identity.xplane.dfds.cloud/v1alpha1
     kind: XAWSRole
   patchSets:
   - name: configname
@@ -45,7 +45,7 @@ spec:
                     
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/role/definition.yaml
+++ b/package/aws/role/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsroles.identity.crossplane.dfds.cloud
+  name: xawsroles.identity.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawsroles.identity.crossplane.dfds.cloud
-  group: identity.crossplane.dfds.cloud
+    name: xawsroles.identity.xplane.dfds.cloud
+  group: identity.xplane.dfds.cloud
   names:
     kind: XAWSRole
     plural: xawsroles

--- a/package/aws/rolepolicyattachement/composition.yaml
+++ b/package/aws/rolepolicyattachement/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawsrolepolicyattachments.identity.crossplane.dfds.cloud
+  name: xawsrolepolicyattachments.identity.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: identity.crossplane.dfds.cloud/v1alpha1
+    apiVersion: identity.xplane.dfds.cloud/v1alpha1
     kind: XAWSRolePolicyAttachment
 
   patchSets:
@@ -22,7 +22,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/rolepolicyattachement/definition.yaml
+++ b/package/aws/rolepolicyattachement/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawsrolepolicyattachments.identity.crossplane.dfds.cloud
+  name: xawsrolepolicyattachments.identity.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawsrolepolicyattachments.identity.crossplane.dfds.cloud
-  group: identity.crossplane.dfds.cloud
+    name: xawsrolepolicyattachments.identity.xplane.dfds.cloud
+  group: identity.xplane.dfds.cloud
   names:
     kind: XAWSRolePolicyAttachment
     plural: xawsrolepolicyattachments

--- a/package/aws/securitygroup/composition.yaml
+++ b/package/aws/securitygroup/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xawssecuritygroups.network.crossplane.dfds.cloud
+  name: xawssecuritygroups.network.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: network.crossplane.dfds.cloud/v1alpha1
+    apiVersion: network.xplane.dfds.cloud/v1alpha1
     kind: XAWSSecurityGroup
 
   patchSets:
@@ -22,7 +22,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/aws/securitygroup/definition.yaml
+++ b/package/aws/securitygroup/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xawssecuritygroups.network.crossplane.dfds.cloud
+  name: xawssecuritygroups.network.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xawssecuritygroups.network.crossplane.dfds.cloud
-  group: network.crossplane.dfds.cloud
+    name: xawssecuritygroups.network.xplane.dfds.cloud
+  group: network.xplane.dfds.cloud
   names:
     kind: XAWSSecurityGroup
     plural: xawssecuritygroups

--- a/package/containerregistries/composition.yaml
+++ b/package/containerregistries/composition.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xcontainerregistries.crossplane.dfds.cloud
+  name: xcontainerregistries.xplane.dfds.cloud
 spec:
   compositeTypeRef:
-    apiVersion: crossplane.dfds.cloud/v1alpha1
+    apiVersion: xplane.dfds.cloud/v1alpha1
     kind: XContainerRegistry
   patchSets:
   - name: configname
@@ -20,7 +20,7 @@ spec:
   resources:
   - name: rbac
     base:
-      apiVersion: crossplane.dfds.cloud/v1alpha1
+      apiVersion: xplane.dfds.cloud/v1alpha1
       kind: XRBAC
       spec:
         resourceTypes:

--- a/package/containerregistries/definition.yaml
+++ b/package/containerregistries/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xcontainerregistries.crossplane.dfds.cloud
+  name: xcontainerregistries.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xcontainerregistries.crossplane.dfds.cloud
-  group: crossplane.dfds.cloud
+    name: xcontainerregistries.xplane.dfds.cloud
+  group: xplane.dfds.cloud
   names:
     kind: XContainerRegistry
     plural: xcontainerregistries

--- a/package/rbac/composition.yaml
+++ b/package/rbac/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xrbacs.crossplane.dfds.cloud
+  name: xrbacs.xplane.dfds.cloud
   labels:
     provider: k8s
 spec:
   compositeTypeRef:
-    apiVersion: crossplane.dfds.cloud/v1alpha1
+    apiVersion: xplane.dfds.cloud/v1alpha1
     kind: XRBAC
   patchSets:
   - name: object-metadata

--- a/package/rbac/definition.yaml
+++ b/package/rbac/definition.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xrbacs.crossplane.dfds.cloud
+  name: xrbacs.xplane.dfds.cloud
 spec:
   defaultCompositionRef:
-    name: xrbacs.crossplane.dfds.cloud
-  group: crossplane.dfds.cloud
+    name: xrbacs.xplane.dfds.cloud
+  group: xplane.dfds.cloud
   names:
     kind: XRBAC
     plural: xrbacs

--- a/package/sqldatabases/composition.yaml
+++ b/package/sqldatabases/composition.yaml
@@ -1,12 +1,12 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: compositesqldatabaseinstances.crossplane.dfds.cloud
+  name: compositesqldatabaseinstances.xplane.dfds.cloud
   labels:
     provider: aws
 spec:
   compositeTypeRef:
-    apiVersion: crossplane.dfds.cloud/v1alpha1
+    apiVersion: xplane.dfds.cloud/v1alpha1
     kind: CompositeSqlDatabaseInstance
   patchSets:
   - name: object-metadata

--- a/package/sqldatabases/definition.yaml
+++ b/package/sqldatabases/definition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: compositesqldatabaseinstances.crossplane.dfds.cloud
+  name: compositesqldatabaseinstances.xplane.dfds.cloud
 spec:
   connectionSecretKeys:
   - username
@@ -9,8 +9,8 @@ spec:
   - hostname
   - port
   defaultCompositionRef:
-    name: compositesqldatabaseinstances.crossplane.dfds.cloud
-  group: crossplane.dfds.cloud
+    name: compositesqldatabaseinstances.xplane.dfds.cloud
+  group: xplane.dfds.cloud
   names:
     kind: CompositeSqlDatabaseInstance
     plural: compositesqldatabaseinstances


### PR DESCRIPTION
This PR renames crossplane.dfds.cloud to xplane.dfds.cloud to reduce the amount of characters used by the api group due to the 63 character limit on resource naming