### PR TITLE
added instructions to readme about eks iam roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ You can find the list of tags at <https://hub.docker.com/repository/docker/dfdsd
 For each namespace in which you wish to provision resources you will need to install a ProviderConfig which follows the convention of 
 namespace name suffixed with `-aws`. See `examples/awsproviderconfig.yaml` which installs a ProviderConfig for the namespace `my-namespace`, resulting in the ProviderConfig name of `my-namespace-aws`.
 
-You will also need to generate a kubernetes secret containing your credentials that the ProviderConfig references. This can be done by placing credentials in a file, i.e `creds.conf` in the format:
+### Using a Credentials file
+
+You will need to generate a kubernetes secret containing your credentials that the ProviderConfig references. This can be done by placing credentials in a file, i.e `creds.conf` in the format:
 
 ```
 [default]
@@ -62,6 +64,182 @@ aws_secret_access_key = SECRETKEYHERE
 ```
 
 And running the command `kubectl create secret generic aws-creds -n my-namespace --from-file=creds=./creds.conf`
+
+### Using IAM role assumption in EKS
+
+Set environment variables to use with commands below
+```
+export AWS_REGION=region-here
+export CLUSTER_NAME=clustername
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+export IAM_ROLE_NAME=name-to-give-iam-role
+SERVICE_ACCOUNT_NAMESPACE=namespace-ie-crossplane-system-or-upbound-system
+```
+
+The first requirement is that you enable IAM roles for service accounts in your cluster by [Creating an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)
+
+```
+eksctl utils associate-iam-oidc-provider --cluster "${CLUSTER_NAME}" --region "${AWS_REGION}" --approve
+```
+
+Our next step is to install Crossplane
+
+```
+kubectl create namespace $SERVICE_ACCOUNT_NAMESPACE
+helm repo add crossplane-stable https://charts.crossplane.io/stable
+helm install crossplane --namespace $SERVICE_ACCOUNT_NAMESPACE crossplane-stable/crossplane
+```
+
+Then install the AWS provider referencing a ControllerConfig containing an annotation
+
+```
+cat > provider.yaml <<EOF
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: aws-config
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::$AWS_ACCOUNT_ID:role/$IAM_ROLE_NAME
+spec:
+  podSecurityContext:
+    fsGroup: 2000
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: crossplane/provider-aws:alpha
+  controllerConfigRef:
+    name: aws-config
+EOF
+
+kubectl apply -f provider.yaml
+```
+
+Then we need to create an IAM role for our service account in our EKS cluster's AWS account
+
+```
+kubectl get serviceaccounts -n $SERVICE_ACCOUNT_NAMESPACE
+SERVICE_ACCOUNT_NAME=provider-aws-[id from aws service account name here]
+```
+
+Using EKSCTL
+```
+#eksctl create iamserviceaccount --cluster "${CLUSTER_NAME}" --region "${AWS_REGION}" --name="$SERVICE_ACCOUNT_NAME" --namespace="$SERVICE_ACCOUNT_NAMESPACE" --role-name="$IAM_ROLE_NAME" --role-only --attach-policy-arn="arn:aws:iam::aws:policy/AdministratorAccess" --approve --override-existing-serviceaccounts
+```
+
+Using AWS CLI
+```
+read -r -d '' TRUST_RELATIONSHIP <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+	"StringLike": {
+          "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:upbound-system:provider-aws-*"
+        }
+      }
+    }
+  ]
+}
+EOF
+echo "${TRUST_RELATIONSHIP}" > trust.json
+
+aws iam create-role --role-name "${IAM_ROLE_NAME}" --assume-role-policy-document file://trust.json --description "IAM role for provider-aws"
+
+aws iam attach-role-policy --role-name "${IAM_ROLE_NAME}" --policy-arn=arn:aws:iam::aws:policy/AdministratorAccess
+```
+
+Then create a ProviderConfig to provision resources in our account
+
+```
+cat > provider-config.yaml <<EOF
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: aws-provider
+spec:
+  assumeRoleARN: "arn:aws:iam::$AWS_ACCOUNT_ID:role/$IAM_ROLE_NAME"
+  credentials:
+    source: InjectedIdentity
+EOF
+
+kubectl apply -f provider-config.yaml
+```
+
+To deploy resources into another AWS account, we need to do the following:
+
+Create a role that trusts the role from our EKS AWS account:
+
+```
+MY_OTHER_AWS_ACCOUNT_IAM_ROLE_NAME=provider-aws
+MY_OTHER_AWS_ACCOUNT_ID=111111111
+```
+
+```
+read -r -d '' TRUST_RELATIONSHIP_OTHER_AWS_ACCOUNT <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::$AWS_ACCOUNT_ID:role/$IAM_ROLE_NAME"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+echo "${TRUST_RELATIONSHIP_OTHER_AWS_ACCOUNT}" > trust_other.json
+
+aws iam create-role --role-name "${MY_OTHER_AWS_ACCOUNT_IAM_ROLE_NAME}" --assume-role-policy-document file://trust_other.json --description "IAM role for $IAM_ROLE_NAME in $AWS_ACCOUNT_ID"
+```
+
+Attach AdministratorAccess permissions to the role:
+
+```
+aws iam attach-role-policy --role-name "${MY_OTHER_AWS_ACCOUNT_IAM_ROLE_NAME}" --policy-arn=arn:aws:iam::aws:policy/AdministratorAccess
+```
+
+Create a new providerconfig set to assume that role. i.e:
+
+```
+cat > provider-config-other.yaml <<EOF
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: aws-provider-$MY_OTHER_AWS_ACCOUNT_ID
+spec:
+  assumeRoleARN: "arn:aws:iam::$MY_OTHER_AWS_ACCOUNT_ID:role/$MY_OTHER_AWS_ACCOUNT_IAM_ROLE_NAME"
+  credentials:
+    source: InjectedIdentity
+EOF
+
+kubectl apply -f provider-config-other.yaml
+```
+
+When creating a resource for this capability, reference this providerconfig. i.e:
+
+```
+apiVersion: efs.aws.crossplane.io/v1alpha1
+kind: FileSystem
+metadata:
+  name: remote-efs-example
+spec:
+  forProvider:
+    region: eu-west-1
+  providerConfigRef:
+    name: aws-provider-$MY_OTHER_AWS_ACCOUNT_ID
+```
 
 ## Setting a Kubernetes ProviderConfig
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: crossplane/provider-aws:alpha
+  package: crossplane/provider-aws:v0.22.0
   controllerConfigRef:
     name: aws-config
 EOF
@@ -124,12 +124,15 @@ kubectl get serviceaccounts -n $SERVICE_ACCOUNT_NAMESPACE
 SERVICE_ACCOUNT_NAME=provider-aws-[id from aws service account name here]
 ```
 
-Using EKSCTL
+Option 1: Using EKSCTL
 ```
 #eksctl create iamserviceaccount --cluster "${CLUSTER_NAME}" --region "${AWS_REGION}" --name="$SERVICE_ACCOUNT_NAME" --namespace="$SERVICE_ACCOUNT_NAMESPACE" --role-name="$IAM_ROLE_NAME" --role-only --attach-policy-arn="arn:aws:iam::aws:policy/AdministratorAccess" --approve --override-existing-serviceaccounts
 ```
 
-Using AWS CLI
+> Note: Using EKSCTL will use StringEquals in the Trust Relationship and use the exact name of the aws-provider service account. This would mean it needs 
+editing with each upgrade of the AWS provider so it is preferrable to use the AWS CLI method below instead
+
+Option 2: Using AWS CLI
 ```
 read -r -d '' TRUST_RELATIONSHIP <<EOF
 {
@@ -144,7 +147,7 @@ read -r -d '' TRUST_RELATIONSHIP <<EOF
       "Condition": {
 	"StringLike": {
           "${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
-          "${OIDC_PROVIDER}:sub": "system:serviceaccount:upbound-system:provider-aws-*"
+          "${OIDC_PROVIDER}:sub": "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:provider-aws-*"
         }
       }
     }


### PR DESCRIPTION
Adds instructions to the main README about using AWS Provider with EKS, using IAM Roles for Service Acounts