### PR TITLE
fix rbac api groups for aws cloudfornt

### DIFF
--- a/package/aws/distribution/v1alpha1/composition.yaml
+++ b/package/aws/distribution/v1alpha1/composition.yaml
@@ -26,7 +26,7 @@ spec:
       kind: XRBACV1
       spec:
         resourceTypes: 
-        - distribution
+        - distributions
         apiGroups: 
         - cloudfront.aws.crossplane.io
         providerConfigRef:


### PR DESCRIPTION
enable capability users to access distribution resources using "kubectl get"
Signed-off-by: Sami Dieb [samdi@dfds.com](mailto:samdi@dfds.com)